### PR TITLE
Update Slack channel link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Learn how to engage with the Kubernetes community on the [community page](http:/
 
 You can reach the maintainers of this project at:
 
-- [Slack channel](https://kubernetes.slack.com/messages/wg-ai-conformance)
+- [Slack channel](https://kubernetes.slack.com/messages/k8s-ai-conformance)
 - [Mailing List](https://groups.google.com/a/kubernetes.io/g/sig-architecture)
 
 ### Code of conduct


### PR DESCRIPTION
It's now #k8s-ai-conformance