### PR TITLE
Automated test: Accelerator Resource Exposure & Allocation

### DIFF
--- a/kars/0051-accelerator-resource-exposure-allocation/README.md
+++ b/kars/0051-accelerator-resource-exposure-allocation/README.md
@@ -38,6 +38,8 @@ This requirement is covered by the upstream Kubernetes conformance test suite st
 
 See [test/conformance/testdata/conformance.yaml](https://github.com/kubernetes/kubernetes/blob/release-1.35/test/conformance/testdata/conformance.yaml#L2935-L2959) and the implementation in [test/e2e/dra/dra.go](https://github.com/kubernetes/kubernetes/blob/release-1.35/test/e2e/dra/dra.go).
 
+Additionally, the AI conformance test suite includes `TestAcceleratorResourceExposureAllocation` (see [test/ai_conformance_test.go](../../test/ai_conformance_test.go)), which uses the discovery API to verify that all four `resource.k8s.io/v1` DRA resource types (`DeviceClass`, `ResourceClaim`, `ResourceClaimTemplate`, `ResourceSlice`) are served and support create/update/list/patch/delete.
+
 ## Implementation History
 
 2026-03-12: KAR created

--- a/test/README.md
+++ b/test/README.md
@@ -30,6 +30,7 @@ go test -v ./test -run 'Test(DetectAllocationMode|ExtendedResourceGuardFailsClos
 | Test Name | Requirement Covered | Requirement Level |
 |-|-|-|
 | `TestSecureAcceleratorAccess` | Secure Accelerator Access | MUST |
+| `TestAcceleratorResourceExposureAllocation` | Accelerator Resource Exposure & Allocation | MUST |
 
 ## Vendor Customization & Neutrality
 

--- a/test/ai_conformance_test.go
+++ b/test/ai_conformance_test.go
@@ -10,8 +10,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // TestSecureAcceleratorAccess verifies the Secure Accelerator Access requirement.
@@ -22,20 +20,7 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		flag.Parse()
 	}
 
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if *kubeconfig != "" {
-		loadingRules.ExplicitPath = *kubeconfig
-	}
-
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
-	if err != nil {
-		t.Fatalf("Error building kubeconfig: %v", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		t.Fatalf("Error creating kubernetes client: %v", err)
-	}
+	clientset := newClientset(t)
 
 	ctx := context.Background()
 	namespace := randomNamespaceName("ai-conformance")
@@ -129,4 +114,30 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		verifyHardwareInLogs(ctx, t, clientset, namespace, podName, "authorized", true)
 		verifyHardwareInLogs(ctx, t, clientset, namespace, podName, "unauthorized", false)
 	})
+}
+
+// TestAcceleratorResourceExposureAllocation verifies the Accelerator Resource
+// Exposure & Allocation requirement: all resource.k8s.io/v1 DRA API resources
+// must be enabled so workloads can request accelerators with fine-grained
+// semantics via Dynamic Resource Allocation.
+// Ref: https://github.com/kubernetes-sigs/ai-conformance/tree/main/kars/0051-accelerator-resource-exposure-allocation
+func TestAcceleratorResourceExposureAllocation(t *testing.T) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	clientset := newClientset(t)
+	served := servedDRAResources(t, clientset)
+
+	// Each DRA resource type must be served and support the verbs needed for
+	// create/update/list/patch/delete operations.
+	for _, resource := range requiredDRAResources {
+		t.Run(resource, func(t *testing.T) {
+			verbs, ok := served[resource]
+			if !ok {
+				t.Fatalf("DRA API resource %s/%s is not served by the API server", draAPIGroupVersion, resource)
+			}
+			verifyDRAVerbs(t, resource, verbs)
+		})
+	}
 }

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -65,6 +66,19 @@ var (
 	}
 	testResourceTemplateName = "accelerator-claim-template"
 	testRequestName          = "single-accelerator"
+
+	// DRA (Dynamic Resource Allocation) GA API group/version and the resource
+	// types it must serve for accelerator resource exposure & allocation.
+	draAPIGroupVersion   = "resource.k8s.io/v1"
+	requiredDRAResources = []string{
+		"deviceclasses",
+		"resourceclaims",
+		"resourceclaimtemplates",
+		"resourceslices",
+	}
+	// Verbs the API server must support for each DRA resource, mirroring the
+	// upstream Kubernetes conformance coverage cited in KAR-0051.
+	requiredDRAVerbs = []string{"create", "update", "list", "patch", "delete"}
 )
 
 func init() {
@@ -88,6 +102,25 @@ func lookupAcceleratorConfig(name string) (AcceleratorConfig, error) {
 		return AcceleratorConfig{}, fmt.Errorf("unsupported accelerator type %q; supported types: %s", name, strings.Join(supported, ", "))
 	}
 	return cfg, nil
+}
+
+// newClientset builds a Kubernetes clientset from the configured kubeconfig.
+func newClientset(t *testing.T) *kubernetes.Clientset {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if *kubeconfig != "" {
+		loadingRules.ExplicitPath = *kubeconfig
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		t.Fatalf("Error building kubeconfig: %v", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Error creating kubernetes client: %v", err)
+	}
+	return clientset
 }
 
 // Setup namespace and, for the DRA allocation mode, the ResourceClaimTemplate
@@ -741,4 +774,34 @@ func acceleratorProbingContainer(name string, cfg AcceleratorConfig) corev1.Cont
 
 func randomNamespaceName(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, rand.String(5))
+}
+
+// servedDRAResources discovers the resources served under resource.k8s.io/v1,
+// keyed by resource name. It fails the test if the DRA API group/version is not
+// enabled, since that means accelerators cannot be requested via DRA.
+func servedDRAResources(t *testing.T, c kubernetes.Interface) map[string]metav1.Verbs {
+	resources, err := c.Discovery().ServerResourcesForGroupVersion(draAPIGroupVersion)
+	if err != nil {
+		t.Fatalf("Failed to discover %s resources. Is the DRA API enabled? Error: %v", draAPIGroupVersion, err)
+	}
+
+	served := map[string]metav1.Verbs{}
+	for _, r := range resources.APIResources {
+		// Skip subresources such as resourceclaims/status.
+		if strings.Contains(r.Name, "/") {
+			continue
+		}
+		served[r.Name] = r.Verbs
+	}
+	return served
+}
+
+// verifyDRAVerbs checks that a DRA resource supports every verb required for
+// create/update/list/patch/delete operations.
+func verifyDRAVerbs(t *testing.T, resource string, verbs metav1.Verbs) {
+	for _, want := range requiredDRAVerbs {
+		if !slices.Contains(verbs, want) {
+			t.Errorf("DRA API resource %q does not support required verb %q (supported verbs: %v)", resource, want, verbs)
+		}
+	}
 }


### PR DESCRIPTION
#51

Adds an automated AI conformance test for KAR-0051 that uses the discovery API to verify all four resource.k8s.io/v1 DRA types (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) are enabled and support create/update/list/patch/delete. The check is read-only and hardware-independent (no accelerator or namespace required), complementing the upstream Kubernetes conformance suite's CRUD coverage cited in the KAR.