### PR TITLE
Add automated test for KAR-0055 accelerator cluster autoscaling

### DIFF
--- a/kars/0055-cluster-autoscaling-for-accelerators/README.md
+++ b/kars/0055-cluster-autoscaling-for-accelerators/README.md
@@ -39,6 +39,8 @@ The test verifies that a cluster autoscaler running on the platform scales node 
 
 4. **Cleanup**: Delete remaining test resources and restore the node pool to its original configuration.
 
+This is implemented by `TestAcceleratorClusterAutoscaling` in the AI conformance test suite (see [test/cluster_autoscaling_test.go](../../test/cluster_autoscaling_test.go)). The test uses a provider-supplied node-pool label and required Pod anti-affinity to place one accelerator-requesting Pod on each baseline node. It validates device-plugin capacity directly and uses isolated baseline allocations plus a Pending trigger to validate effective DRA capacity. The pool must have no competing workloads or accelerator demand. The additional trigger Pod carries neither the baseline run label nor anti-affinity, so exhausted accelerator capacity is its only expected unsatisfied target-pool constraint. The test verifies that the selected pool gains Ready capacity, the Pod runs on a Node UID outside the stable baseline, and the pool returns to the original Ready, schedulable baseline after the Pod is deleted. A retained NotReady Node object does not fail scale-down because Kubernetes does not provide a portable cloud node-group size API. The test observes a preconfigured pool and does not modify provider node-pool settings.
+
 ## Implementation History
 
 2026-03-12: KAR created

--- a/kars/0055-cluster-autoscaling-for-accelerators/README.md
+++ b/kars/0055-cluster-autoscaling-for-accelerators/README.md
@@ -31,6 +31,12 @@ Prepare a node pool with N nodes, configured with a specific accelerator type, w
 
 The test verifies that a cluster autoscaler running on the platform scales node groups up and down based on pending pods requesting accelerator resources.
 
+This requirement is conditional. If the platform does not provide a cluster
+autoscaler or an equivalent mechanism, participants may mark
+`cluster_autoscaling` as `N/A` with a justification and skip this automated
+test. Platforms that provide such a mechanism must run the test and configure
+the provider-specific node-pool label described below.
+
 1. **Setup**: Configure a node pool with N nodes, each providing exactly 1 accelerator of type A, with a minimum size of N and a maximum size of at least N+1.
 
 2. **Scale-up case**: Create N+1 Pods, each requesting one accelerator of type A from the pool. Verify that at least one Pod is initially `Pending`, the node count grows to N+1, and the Pending Pod transitions to `Running`.

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,7 @@ To run these AI Conformance tests, you must have:
 - Golang: Installed on your local machine.
 - Kubeconfig: A valid kubeconfig file with cluster-admin permissions for the target cluster.
 - Accelerator Node Pool: The cluster must have nodes with accelerators exposed through the Kubernetes resource management framework — either a DRA driver (ResourceClaims against a DeviceClass such as `gpu.nvidia.com`) or a device plugin (extended resources such as `nvidia.com/gpu`). Make sure your nodes allow testing pods to be scheduled on them (e.g. no taints that prevent scheduling).
+- Cluster Autoscaling Test: `TestAcceleratorClusterAutoscaling` additionally requires a running cluster autoscaler and an isolated accelerator pool with minimum size `N >= 1`, maximum size at least `N+1`, effective capacity for exactly one requested accelerator per baseline node, scale-down enabled, sufficient cloud quota/stock, and one stable node label inherited by new pool nodes. The pool must contain no non-DaemonSet workloads or other Pending Pods explicitly selecting the pool. Device-plugin mode permits unrelated running accelerator workloads outside the pool but rejects other Pending Pods requesting the configured extended resource. DRA mode requires no other active Pods with ResourceClaims or allocated ResourceClaims outside the test namespace while the test runs because DRA devices may use shared topology.
 - Network Access: The test machine must be able to reach the Kubernetes API server.
 
 ## Running the Tests
@@ -31,6 +32,63 @@ go test -v ./test -run 'Test(DetectAllocationMode|ExtendedResourceGuardFailsClos
 |-|-|-|
 | `TestSecureAcceleratorAccess` | Secure Accelerator Access | MUST |
 | `TestGangScheduling` | Gang Scheduling | MUST |
+| `TestAcceleratorClusterAutoscaling` | Effective Cluster Autoscaling for Accelerators | MUST |
+
+### Accelerator Cluster Autoscaling
+
+The autoscaling test observes a preconfigured accelerator pool; it does not
+modify provider node-pool settings. Use a node label that uniquely identifies
+the target pool. The example below uses the AKS `agentpool` label; replace it
+with the corresponding label for your platform.
+
+Baseline Pods use hostname anti-affinity to occupy distinct pool nodes. The
+trigger Pod carries neither that anti-affinity nor its matching label, so
+exhausted accelerator capacity is the only target-pool constraint that can
+leave it Pending. A PodDisruptionBudget protects the baseline Pods while the
+added node is idle and eligible for scale-down. The test fails if pool
+membership changes or foreign accelerator demand appears during scale-up.
+
+Device-plugin mode rejects extended resources backed by a DRA DeviceClass and
+checks every observed pool node for exactly one allocatable extended resource.
+DRA has no portable per-node allocatable count, so the isolated baseline Pods
+and Pending trigger verify that the selected DeviceClass has effective capacity
+for exactly `N` allocations before scale-up.
+
+Scale-up and scale-down can take significantly longer than Go's default test
+timeout, so use `-timeout 75m` or a larger value.
+
+```bash
+go test -v ./test \
+  -run TestAcceleratorClusterAutoscaling \
+  -timeout 75m \
+  -accelerator-type=nvidia \
+  -autoscaler-allocation-mode=device-plugin \
+  -autoscaler-node-pool-label=agentpool=gpupool
+```
+
+To test DRA autoscaling, the cluster autoscaler must have DRA support enabled:
+
+```bash
+go test -v ./test \
+  -run TestAcceleratorClusterAutoscaling \
+  -timeout 75m \
+  -accelerator-type=nvidia \
+  -autoscaler-allocation-mode=dra \
+  -autoscaler-node-pool-label=agentpool=gpupool
+```
+
+The following optional flags control observation windows:
+
+- `-autoscaler-pending-timeout` (default `2m`)
+- `-autoscaler-scale-up-timeout` (default `20m`)
+- `-autoscaler-scale-down-timeout` (default `30m`)
+- `-autoscaler-stability-window` (default `30s`)
+
+Scale-down passes when the original baseline Node UIDs remain Ready and schedulable, the added
+Node UID is no longer Ready or has been deleted, and the selected pool has
+exactly `N` Ready Nodes for the stability window. The Kubernetes API cannot
+portably prove a cloud provider's node-group size, and Cluster Autoscaler does
+not itself guarantee deletion of the Kubernetes `Node` object.
 
 ## Vendor Customization & Neutrality
 

--- a/test/README.md
+++ b/test/README.md
@@ -41,6 +41,12 @@ modify provider node-pool settings. Use a node label that uniquely identifies
 the target pool. The example below uses the AKS `agentpool` label; replace it
 with the corresponding label for your platform.
 
+The test is skipped when `-autoscaler-node-pool-label` is unset. Platforms that
+do not provide a cluster autoscaler or equivalent mechanism may mark the
+`cluster_autoscaling` requirement as `N/A` with a justification and leave the
+flag unset. Platforms that provide autoscaling must configure the flag and run
+the test; a skipped result is not evidence that the requirement is implemented.
+
 Baseline Pods use hostname anti-affinity to occupy distinct pool nodes. The
 trigger Pod carries neither that anti-affinity nor its matching label, so
 exhausted accelerator capacity is the only target-pool constraint that can

--- a/test/README.md
+++ b/test/README.md
@@ -54,6 +54,11 @@ DRA has no portable per-node allocatable count, so the isolated baseline Pods
 and Pending trigger verify that the selected DeviceClass has effective capacity
 for exactly `N` allocations before scale-up.
 
+The suite-wide `-allocation-mode` flag controls the allocation mechanism for
+all accelerator tests. Its default `auto` mode prefers DRA when usable and
+otherwise falls back to the device plugin. Use an explicit mode when testing a
+hybrid cluster where the selected pool supports only one mechanism.
+
 Scale-up and scale-down can take significantly longer than Go's default test
 timeout, so use `-timeout 75m` or a larger value.
 
@@ -62,7 +67,7 @@ go test -v ./test \
   -run TestAcceleratorClusterAutoscaling \
   -timeout 75m \
   -accelerator-type=nvidia \
-  -autoscaler-allocation-mode=device-plugin \
+  -allocation-mode=device-plugin \
   -autoscaler-node-pool-label=agentpool=gpupool
 ```
 
@@ -73,7 +78,7 @@ go test -v ./test \
   -run TestAcceleratorClusterAutoscaling \
   -timeout 75m \
   -accelerator-type=nvidia \
-  -autoscaler-allocation-mode=dra \
+  -allocation-mode=dra \
   -autoscaler-node-pool-label=agentpool=gpupool
 ```
 

--- a/test/ai_conformance_test.go
+++ b/test/ai_conformance_test.go
@@ -4,14 +4,8 @@ import (
 	"context"
 	"flag"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // TestSecureAcceleratorAccess verifies the Secure Accelerator Access requirement.
@@ -22,48 +16,14 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		flag.Parse()
 	}
 
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if *kubeconfig != "" {
-		loadingRules.ExplicitPath = *kubeconfig
-	}
-
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
-	if err != nil {
-		t.Fatalf("Error building kubeconfig: %v", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		t.Fatalf("Error creating kubernetes client: %v", err)
-	}
+	clientset := getClientset(t)
 
 	ctx := context.Background()
 	namespace := randomNamespaceName("ai-conformance")
 
 	t.Cleanup(func() {
-		t.Logf("Cleaning up namespace %s...", namespace)
-		err := clientset.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
-		if apierrors.IsNotFound(err) {
-			// The test failed before the namespace was created; nothing to clean up.
-			return
-		}
-		if err != nil {
-			t.Errorf("Failed to cleanup namespace: %v", err)
-		}
-
-		// Poll until the namespace is actually gone; this is needed because the namespace needs to release resources for rerunning tests
-		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-			_, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, nil
-		})
-		if err != nil {
-			t.Errorf("CLEANUP FAILURE: Failed to delete namespace %s: %v. "+
-				"Please ensure this namespace is terminated manually to avoid resource leaks."+
-				"Rerunning the tests might fail if the namespace is not deleted.",
-				namespace, err)
+		if err := deleteNamespaceAndWait(ctx, t, clientset, namespace); err != nil {
+			t.Errorf("CLEANUP FAILURE: %v. Please ensure this namespace is terminated manually to avoid resource leaks.", err)
 		}
 	})
 
@@ -85,7 +45,9 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		podName := "pos-pod"
 		var pod *corev1.Pod
 		t.Cleanup(func() {
-			deletePodAndWait(ctx, t, clientset, namespace, podName, pod)
+			if err := deletePodAndWait(ctx, clientset, namespace, podName, pod); err != nil {
+				t.Errorf("Cleanup of Pod %s incomplete; subsequent accelerator tests may race its device/claim release: %v", podName, err)
+			}
 		})
 		pod = runTestPod(ctx, t, clientset, namespace, podName, []corev1.Container{acceleratorProbingContainer("prober", cfg)},
 			testPodConfig{grantAccelerator: true, mode: mode, cfg: cfg})
@@ -108,7 +70,9 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		podName := "neg-pod"
 		var pod *corev1.Pod
 		t.Cleanup(func() {
-			deletePodAndWait(ctx, t, clientset, namespace, podName, pod)
+			if err := deletePodAndWait(ctx, clientset, namespace, podName, pod); err != nil {
+				t.Errorf("Cleanup of Pod %s incomplete; subsequent accelerator tests may race its device/claim release: %v", podName, err)
+			}
 		})
 		pod = runTestPod(ctx, t, clientset, namespace, podName, []corev1.Container{acceleratorProbingContainer("prober", cfg)},
 			testPodConfig{grantAccelerator: false, mode: mode, nodeName: acceleratorNode, cfg: cfg})
@@ -120,7 +84,9 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		podName := "multi-container-pod"
 		var pod *corev1.Pod
 		t.Cleanup(func() {
-			deletePodAndWait(ctx, t, clientset, namespace, podName, pod)
+			if err := deletePodAndWait(ctx, clientset, namespace, podName, pod); err != nil {
+				t.Errorf("Cleanup of Pod %s incomplete; subsequent accelerator tests may race its device/claim release: %v", podName, err)
+			}
 		})
 		pod = runTestPod(ctx, t, clientset, namespace, podName, []corev1.Container{acceleratorProbingContainer("authorized", cfg), acceleratorProbingContainer("unauthorized", cfg)},
 			testPodConfig{grantAccelerator: true, mode: mode, cfg: cfg})

--- a/test/cleanup_test.go
+++ b/test/cleanup_test.go
@@ -9,8 +9,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -32,6 +34,50 @@ func claim(ns, name string, allocated bool) *resourcev1.ResourceClaim {
 		rc.Status.Allocation = &resourcev1.AllocationResult{}
 	}
 	return rc
+}
+
+func TestWaitForPodsRunning(t *testing.T) {
+	ns := "ns"
+
+	t.Run("returns all running pods", func(t *testing.T) {
+		client := fake.NewClientset(
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: ns}, Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: ns}, Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+		)
+		pods, err := waitForPodsRunning(context.Background(), client, ns, []string{"a", "b"}, time.Second)
+		if err != nil {
+			t.Fatalf("waitForPodsRunning unexpected error: %v", err)
+		}
+		if len(pods) != 2 || pods["a"] == nil || pods["b"] == nil {
+			t.Fatalf("waitForPodsRunning returned %v, want Pods a and b", pods)
+		}
+	})
+
+	t.Run("times out while a pod is pending", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		client := fake.NewClientset(
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: ns}, Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: ns}, Status: corev1.PodStatus{Phase: corev1.PodPending}},
+		)
+		if _, err := waitForPodsRunning(ctx, client, ns, []string{"a", "b"}, time.Second); err == nil {
+			t.Fatal("waitForPodsRunning expected timeout")
+		}
+	})
+
+	t.Run("fails fast on a permanent API error", func(t *testing.T) {
+		client := fake.NewClientset()
+		client.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "a", errors.New("denied"))
+		})
+		start := time.Now()
+		if _, err := waitForPodsRunning(context.Background(), client, ns, []string{"a"}, time.Second); err == nil {
+			t.Fatal("waitForPodsRunning expected permanent API error")
+		}
+		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Fatalf("permanent API error took %s to return", elapsed)
+		}
+	})
 }
 
 func TestPodGeneratedClaims(t *testing.T) {
@@ -183,4 +229,46 @@ func TestDeleteAndAwaitRelease(t *testing.T) {
 			t.Fatalf("expected delete error to propagate, got %v", err)
 		}
 	})
+
+	t.Run("retries transient pod delete API errors", func(t *testing.T) {
+		client := fake.NewClientset(podWithClaimStatus(ns, "p", "c"))
+		attempts := 0
+		client.PrependReactor("delete", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+			attempts++
+			if attempts == 1 {
+				return true, nil, apierrors.NewTooManyRequests("busy", 0)
+			}
+			return false, nil, nil
+		})
+		if err := deleteAndAwaitRelease(context.Background(), client, ns, "p", nil); err != nil {
+			t.Fatalf("deleteAndAwaitRelease unexpected error: %v", err)
+		}
+		if attempts != 2 {
+			t.Fatalf("delete attempts = %d, want 2", attempts)
+		}
+	})
+}
+
+func TestIsRetryableAPIError(t *testing.T) {
+	if !isRetryableAPIError(apierrors.NewTooManyRequests("busy", 0)) {
+		t.Fatal("TooManyRequests should be retryable")
+	}
+	if isRetryableAPIError(apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "p", errors.New("denied"))) {
+		t.Fatal("Forbidden should not be retryable")
+	}
+}
+
+func TestDeletePodAndWait(t *testing.T) {
+	client := fake.NewClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}})
+	getAttempts := 0
+	client.PrependReactor("get", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		getAttempts++
+		if getAttempts == 1 {
+			return true, nil, errors.New("temporary read failure")
+		}
+		return false, nil, nil
+	})
+	if err := deletePodAndWait(context.Background(), client, "ns", "p", nil); err != nil {
+		t.Fatalf("deletePodAndWait unexpected error after confirmed release: %v", err)
+	}
 }

--- a/test/cluster_autoscaling_test.go
+++ b/test/cluster_autoscaling_test.go
@@ -41,7 +41,7 @@ var (
 
 func init() {
 	autoscalerNodePoolLabel = flag.String("autoscaler-node-pool-label", "",
-		"Node label identifying the accelerator pool to test, in key=value form. The test is skipped when unset.")
+		"Node label identifying the accelerator pool to test, in key=value form. The test is skipped when unset for platforms where cluster_autoscaling is N/A.")
 	autoscalerPendingTimeout = flag.Duration("autoscaler-pending-timeout", 2*time.Minute,
 		"How long to wait for the scale-up trigger Pod to become Unschedulable.")
 	autoscalerScaleUpTimeout = flag.Duration("autoscaler-scale-up-timeout", 20*time.Minute,
@@ -61,7 +61,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 		flag.Parse()
 	}
 	if *autoscalerNodePoolLabel == "" {
-		t.Skip("set -autoscaler-node-pool-label=<key>=<value> to run the accelerator cluster autoscaling test")
+		t.Skip("cluster autoscaling test is not configured; if the platform has no cluster autoscaler, mark cluster_autoscaling N/A, otherwise set -autoscaler-node-pool-label=<key>=<value>")
 	}
 
 	poolKey, poolValue, err := parseNodePoolLabel(*autoscalerNodePoolLabel)

--- a/test/cluster_autoscaling_test.go
+++ b/test/cluster_autoscaling_test.go
@@ -33,7 +33,6 @@ type nodeReference struct {
 
 var (
 	autoscalerNodePoolLabel    *string
-	autoscalerAllocationMode   *string
 	autoscalerPendingTimeout   *time.Duration
 	autoscalerScaleUpTimeout   *time.Duration
 	autoscalerScaleDownTimeout *time.Duration
@@ -43,8 +42,6 @@ var (
 func init() {
 	autoscalerNodePoolLabel = flag.String("autoscaler-node-pool-label", "",
 		"Node label identifying the accelerator pool to test, in key=value form. The test is skipped when unset.")
-	autoscalerAllocationMode = flag.String("autoscaler-allocation-mode", allocationModeDevicePlugin,
-		"How autoscaling test pods request accelerators: 'device-plugin' (default) or 'dra'.")
 	autoscalerPendingTimeout = flag.Duration("autoscaler-pending-timeout", 2*time.Minute,
 		"How long to wait for the scale-up trigger Pod to become Unschedulable.")
 	autoscalerScaleUpTimeout = flag.Duration("autoscaler-scale-up-timeout", 20*time.Minute,
@@ -71,9 +68,6 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Invalid -autoscaler-node-pool-label: %v", err)
 	}
-	if err := validateAutoscalerAllocationMode(*autoscalerAllocationMode); err != nil {
-		t.Fatalf("Invalid -autoscaler-allocation-mode: %v", err)
-	}
 	if err := validateAutoscalerDurations(
 		*autoscalerPendingTimeout,
 		*autoscalerScaleUpTimeout,
@@ -89,6 +83,11 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 
 	ctx := context.Background()
 	clientset := getClientset(t)
+	mode, _, err := detectAllocationMode(ctx, clientset, *allocationMode, cfg, t.Logf)
+	if err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: Failed to resolve allocation mode: %v", err)
+	}
+	t.Logf("Accelerator autoscaling test running with allocation mode: %s", mode)
 
 	// Capture the stable size and accelerator capacity of the target node pool.
 	initialNodes, err := readyPoolNodes(ctx, clientset, poolKey, poolValue)
@@ -106,10 +105,10 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	baselineCount := len(baselineNodes)
 	t.Logf("Captured accelerator pool baseline: %d Ready, schedulable nodes matching %s=%s", baselineCount, poolKey, poolValue)
 
-	if err := verifyAutoscalerPoolCapacity(ctx, clientset, baselineNodes, *autoscalerAllocationMode, cfg); err != nil {
+	if err := verifyAutoscalerPoolCapacity(ctx, clientset, baselineNodes, mode, cfg); err != nil {
 		t.Fatalf("ENVIRONMENT ERROR: %v", err)
 	}
-	if err := verifyPoolIsIdle(ctx, clientset, "", baselineNodes, poolKey, poolValue, *autoscalerAllocationMode, cfg); err != nil {
+	if err := verifyPoolIsIdle(ctx, clientset, "", baselineNodes, poolKey, poolValue, mode, cfg); err != nil {
 		t.Fatalf("ENVIRONMENT ERROR: %v", err)
 	}
 
@@ -119,7 +118,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 			t.Errorf("CLEANUP FAILURE: %v. Please ensure this namespace is terminated manually to avoid resource leaks.", err)
 		}
 	})
-	setupTestEnvironment(ctx, t, clientset, namespace, *autoscalerAllocationMode, cfg)
+	setupTestEnvironment(ctx, t, clientset, namespace, mode, cfg)
 
 	// Keep one accelerator Pod running on every baseline node.
 	runLabelValue := randomNamespaceName("run")
@@ -141,7 +140,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	baselinePodNames := make([]string, 0, baselineCount)
 	for i := 0; i < baselineCount; i++ {
 		name := fmt.Sprintf("autoscaler-baseline-%d", i)
-		pod, err := buildAutoscalingPod(namespace, name, runLabelValue, poolKey, poolValue, *autoscalerAllocationMode, cfg, true)
+		pod, err := buildAutoscalingPod(namespace, name, runLabelValue, poolKey, poolValue, mode, cfg, true)
 		if err != nil {
 			t.Fatalf("Failed to build baseline Pod %s: %v", name, err)
 		}
@@ -167,14 +166,14 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	if !sameNodeIdentitySet(currentBaseline, baselineNodes) {
 		t.Fatalf("ENVIRONMENT ERROR: Accelerator pool membership changed while establishing the baseline")
 	}
-	if err := verifyPoolIsIdle(ctx, clientset, namespace, currentBaseline, poolKey, poolValue, *autoscalerAllocationMode, cfg); err != nil {
+	if err := verifyPoolIsIdle(ctx, clientset, namespace, currentBaseline, poolKey, poolValue, mode, cfg); err != nil {
 		t.Fatalf("ENVIRONMENT ERROR: %v", err)
 	}
 	t.Logf("Baseline established: %d accelerator Pods occupy %d distinct pool nodes", baselineCount, baselineCount)
 
 	// Create one additional Pod and verify it initially cannot be scheduled.
 	triggerName := "autoscaler-trigger"
-	trigger, err := buildAutoscalingPod(namespace, triggerName, runLabelValue, poolKey, poolValue, *autoscalerAllocationMode, cfg, false)
+	trigger, err := buildAutoscalingPod(namespace, triggerName, runLabelValue, poolKey, poolValue, mode, cfg, false)
 	if err != nil {
 		t.Fatalf("Failed to build scale-up trigger Pod: %v", err)
 	}
@@ -185,7 +184,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FAIL: Scale-up trigger Pod did not become Unschedulable: %v", err)
 	}
-	if *autoscalerAllocationMode == allocationModeDevicePlugin && !strings.Contains(message, cfg.ExtendedResource) {
+	if mode == allocationModeDevicePlugin && !strings.Contains(message, cfg.ExtendedResource) {
 		t.Fatalf("FAIL: Scale-up trigger was Unschedulable for a reason unrelated to %s: %s", cfg.ExtendedResource, message)
 	}
 	t.Logf("Scale-up triggered by Pending Pod %s: %s", triggerName, message)
@@ -199,7 +198,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 		poolKey,
 		poolValue,
 		baselineNodes,
-		*autoscalerAllocationMode,
+		mode,
 		cfg,
 		*autoscalerScaleUpTimeout,
 	)
@@ -209,7 +208,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	createdPods[triggerName] = runningTrigger
 	scaledNode := scaledNodes[runningTrigger.Spec.NodeName]
 	scaledNodeRef := nodeReference{name: scaledNode.Name, uid: scaledNode.UID}
-	if err := verifyAutoscalerPoolCapacity(ctx, clientset, scaledNodes, *autoscalerAllocationMode, cfg); err != nil {
+	if err := verifyAutoscalerPoolCapacity(ctx, clientset, scaledNodes, mode, cfg); err != nil {
 		t.Fatalf("FAIL: Scaled pool did not preserve the accelerator allocation contract: %v", err)
 	}
 	t.Logf("PASS: Accelerator pool scaled from %d to %d nodes; trigger Pod is Running on new node %s", baselineCount, len(scaledNodes), scaledNodeRef.name)
@@ -250,16 +249,6 @@ func parseNodePoolLabel(value string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid label value %q: %s", labelValue, strings.Join(errs, "; "))
 	}
 	return key, labelValue, nil
-}
-
-func validateAutoscalerAllocationMode(mode string) error {
-	switch mode {
-	case allocationModeDevicePlugin, allocationModeDRA:
-		return nil
-	default:
-		return fmt.Errorf("supported values are %q and %q; automatic detection is not used because the target pool must be deterministic",
-			allocationModeDevicePlugin, allocationModeDRA)
-	}
 }
 
 func validateAutoscalerDurations(pending, scaleUp, scaleDown, stableFor time.Duration) error {

--- a/test/cluster_autoscaling_test.go
+++ b/test/cluster_autoscaling_test.go
@@ -1,0 +1,741 @@
+package conformance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	autoscalerRunLabelKey    = "ai-conformance.kubernetes.io/autoscaler-run"
+	baselinePodTimeout       = 5 * time.Minute
+	baselineStabilityWindow  = 30 * time.Second
+	baselineStabilityTimeout = 2 * time.Minute
+)
+
+type nodeReference struct {
+	name string
+	uid  types.UID
+}
+
+var (
+	autoscalerNodePoolLabel    *string
+	autoscalerAllocationMode   *string
+	autoscalerPendingTimeout   *time.Duration
+	autoscalerScaleUpTimeout   *time.Duration
+	autoscalerScaleDownTimeout *time.Duration
+	autoscalerStabilityWindow  *time.Duration
+)
+
+func init() {
+	autoscalerNodePoolLabel = flag.String("autoscaler-node-pool-label", "",
+		"Node label identifying the accelerator pool to test, in key=value form. The test is skipped when unset.")
+	autoscalerAllocationMode = flag.String("autoscaler-allocation-mode", allocationModeDevicePlugin,
+		"How autoscaling test pods request accelerators: 'device-plugin' (default) or 'dra'.")
+	autoscalerPendingTimeout = flag.Duration("autoscaler-pending-timeout", 2*time.Minute,
+		"How long to wait for the scale-up trigger Pod to become Unschedulable.")
+	autoscalerScaleUpTimeout = flag.Duration("autoscaler-scale-up-timeout", 20*time.Minute,
+		"How long to wait for the accelerator pool to scale up and schedule the trigger Pod.")
+	autoscalerScaleDownTimeout = flag.Duration("autoscaler-scale-down-timeout", 30*time.Minute,
+		"How long to wait for the accelerator pool to return to its baseline size.")
+	autoscalerStabilityWindow = flag.Duration("autoscaler-stability-window", 30*time.Second,
+		"How long the accelerator pool must remain at baseline size before scale-down passes.")
+}
+
+// TestAcceleratorClusterAutoscaling verifies that a pending accelerator Pod
+// causes the selected accelerator node pool to scale up, and that the pool
+// returns to its baseline size after the Pod is deleted.
+// Ref: https://github.com/kubernetes-sigs/ai-conformance/tree/main/kars/0055-cluster-autoscaling-for-accelerators
+func TestAcceleratorClusterAutoscaling(t *testing.T) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	if *autoscalerNodePoolLabel == "" {
+		t.Skip("set -autoscaler-node-pool-label=<key>=<value> to run the accelerator cluster autoscaling test")
+	}
+
+	poolKey, poolValue, err := parseNodePoolLabel(*autoscalerNodePoolLabel)
+	if err != nil {
+		t.Fatalf("Invalid -autoscaler-node-pool-label: %v", err)
+	}
+	if err := validateAutoscalerAllocationMode(*autoscalerAllocationMode); err != nil {
+		t.Fatalf("Invalid -autoscaler-allocation-mode: %v", err)
+	}
+	if err := validateAutoscalerDurations(
+		*autoscalerPendingTimeout,
+		*autoscalerScaleUpTimeout,
+		*autoscalerScaleDownTimeout,
+		*autoscalerStabilityWindow,
+	); err != nil {
+		t.Fatalf("Invalid autoscaler timeout configuration: %v", err)
+	}
+	cfg, err := lookupAcceleratorConfig(*acceleratorType)
+	if err != nil {
+		t.Fatalf("Invalid -accelerator-type: %v", err)
+	}
+
+	ctx := context.Background()
+	clientset := getClientset(t)
+
+	// Capture the stable size and accelerator capacity of the target node pool.
+	initialNodes, err := readyPoolNodes(ctx, clientset, poolKey, poolValue)
+	if err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: Failed to list accelerator pool nodes: %v", err)
+	}
+	if len(initialNodes) == 0 {
+		t.Fatalf("ENVIRONMENT ERROR: No Ready, schedulable nodes match accelerator pool label %s=%s", poolKey, poolValue)
+	}
+
+	baselineNodes, err := waitForStablePoolSize(ctx, clientset, poolKey, poolValue, len(initialNodes), baselineStabilityWindow, baselineStabilityTimeout)
+	if err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: Accelerator pool did not have a stable baseline size: %v", err)
+	}
+	baselineCount := len(baselineNodes)
+	t.Logf("Captured accelerator pool baseline: %d Ready, schedulable nodes matching %s=%s", baselineCount, poolKey, poolValue)
+
+	if err := verifyAutoscalerPoolCapacity(ctx, clientset, baselineNodes, *autoscalerAllocationMode, cfg); err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: %v", err)
+	}
+	if err := verifyPoolIsIdle(ctx, clientset, "", baselineNodes, poolKey, poolValue, *autoscalerAllocationMode, cfg); err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: %v", err)
+	}
+
+	namespace := randomNamespaceName("accelerator-autoscaling")
+	t.Cleanup(func() {
+		if err := deleteNamespaceAndWait(ctx, t, clientset, namespace); err != nil {
+			t.Errorf("CLEANUP FAILURE: %v. Please ensure this namespace is terminated manually to avoid resource leaks.", err)
+		}
+	})
+	setupTestEnvironment(ctx, t, clientset, namespace, *autoscalerAllocationMode, cfg)
+
+	// Keep one accelerator Pod running on every baseline node.
+	runLabelValue := randomNamespaceName("run")
+	createBaselinePDB(ctx, t, clientset, namespace, runLabelValue, baselineCount)
+	createdPods := map[string]*corev1.Pod{}
+	t.Cleanup(func() {
+		names := make([]string, 0, len(createdPods))
+		for name := range createdPods {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if err := deletePodAndWait(ctx, clientset, namespace, name, createdPods[name]); err != nil {
+				t.Errorf("Cleanup of Pod %s incomplete; subsequent accelerator tests may race its device/claim release: %v", name, err)
+			}
+		}
+	})
+
+	baselinePodNames := make([]string, 0, baselineCount)
+	for i := 0; i < baselineCount; i++ {
+		name := fmt.Sprintf("autoscaler-baseline-%d", i)
+		pod, err := buildAutoscalingPod(namespace, name, runLabelValue, poolKey, poolValue, *autoscalerAllocationMode, cfg, true)
+		if err != nil {
+			t.Fatalf("Failed to build baseline Pod %s: %v", name, err)
+		}
+		createTestPod(ctx, t, clientset, pod)
+		createdPods[name] = pod
+		baselinePodNames = append(baselinePodNames, name)
+	}
+
+	runningBaseline, err := waitForPodsRunning(ctx, clientset, namespace, baselinePodNames, baselinePodTimeout)
+	if err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: Baseline accelerator Pods did not all reach Running: %v", err)
+	}
+	if err := verifyBaselinePlacement(runningBaseline, baselineNodes); err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: %v", err)
+	}
+	for name, pod := range runningBaseline {
+		createdPods[name] = pod
+	}
+	currentBaseline, err := readyPoolNodes(ctx, clientset, poolKey, poolValue)
+	if err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: Failed to recheck accelerator pool nodes: %v", err)
+	}
+	if !sameNodeIdentitySet(currentBaseline, baselineNodes) {
+		t.Fatalf("ENVIRONMENT ERROR: Accelerator pool membership changed while establishing the baseline")
+	}
+	if err := verifyPoolIsIdle(ctx, clientset, namespace, currentBaseline, poolKey, poolValue, *autoscalerAllocationMode, cfg); err != nil {
+		t.Fatalf("ENVIRONMENT ERROR: %v", err)
+	}
+	t.Logf("Baseline established: %d accelerator Pods occupy %d distinct pool nodes", baselineCount, baselineCount)
+
+	// Create one additional Pod and verify it initially cannot be scheduled.
+	triggerName := "autoscaler-trigger"
+	trigger, err := buildAutoscalingPod(namespace, triggerName, runLabelValue, poolKey, poolValue, *autoscalerAllocationMode, cfg, false)
+	if err != nil {
+		t.Fatalf("Failed to build scale-up trigger Pod: %v", err)
+	}
+	createTestPod(ctx, t, clientset, trigger)
+	createdPods[triggerName] = trigger
+
+	message, err := waitForPodUnschedulable(ctx, clientset, namespace, triggerName, *autoscalerPendingTimeout)
+	if err != nil {
+		t.Fatalf("FAIL: Scale-up trigger Pod did not become Unschedulable: %v", err)
+	}
+	if *autoscalerAllocationMode == allocationModeDevicePlugin && !strings.Contains(message, cfg.ExtendedResource) {
+		t.Fatalf("FAIL: Scale-up trigger was Unschedulable for a reason unrelated to %s: %s", cfg.ExtendedResource, message)
+	}
+	t.Logf("Scale-up triggered by Pending Pod %s: %s", triggerName, message)
+
+	// Verify the pool adds a node that can run the pending accelerator Pod.
+	runningTrigger, scaledNodes, err := waitForTriggerRunningAfterScaleUp(
+		ctx,
+		clientset,
+		namespace,
+		triggerName,
+		poolKey,
+		poolValue,
+		baselineNodes,
+		*autoscalerAllocationMode,
+		cfg,
+		*autoscalerScaleUpTimeout,
+	)
+	if err != nil {
+		t.Fatalf("FAIL: Accelerator pool did not scale up successfully: %v", err)
+	}
+	createdPods[triggerName] = runningTrigger
+	scaledNode := scaledNodes[runningTrigger.Spec.NodeName]
+	scaledNodeRef := nodeReference{name: scaledNode.Name, uid: scaledNode.UID}
+	if err := verifyAutoscalerPoolCapacity(ctx, clientset, scaledNodes, *autoscalerAllocationMode, cfg); err != nil {
+		t.Fatalf("FAIL: Scaled pool did not preserve the accelerator allocation contract: %v", err)
+	}
+	t.Logf("PASS: Accelerator pool scaled from %d to %d nodes; trigger Pod is Running on new node %s", baselineCount, len(scaledNodes), scaledNodeRef.name)
+
+	if err := deletePodAndWait(ctx, clientset, namespace, triggerName, runningTrigger); err != nil {
+		t.Fatalf("FAIL: Trigger Pod and generated claims were not released: %v", err)
+	}
+	delete(createdPods, triggerName)
+
+	// Verify the idle node is removed and the pool returns to its baseline size.
+	if err := waitForScaleDown(
+		ctx,
+		clientset,
+		poolKey,
+		poolValue,
+		scaledNodeRef,
+		baselineNodes,
+		*autoscalerStabilityWindow,
+		*autoscalerScaleDownTimeout,
+	); err != nil {
+		t.Fatalf("FAIL: Accelerator pool did not scale down to its baseline size: %v", err)
+	}
+	t.Logf("PASS: Accelerator pool returned to its baseline size of %d nodes", baselineCount)
+}
+
+func parseNodePoolLabel(value string) (string, string, error) {
+	if strings.Count(value, "=") != 1 {
+		return "", "", fmt.Errorf("expected exactly one key=value pair, got %q", value)
+	}
+	key, labelValue, _ := strings.Cut(value, "=")
+	if key == "" || labelValue == "" {
+		return "", "", fmt.Errorf("label key and value must both be non-empty")
+	}
+	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+		return "", "", fmt.Errorf("invalid label key %q: %s", key, strings.Join(errs, "; "))
+	}
+	if errs := validation.IsValidLabelValue(labelValue); len(errs) > 0 {
+		return "", "", fmt.Errorf("invalid label value %q: %s", labelValue, strings.Join(errs, "; "))
+	}
+	return key, labelValue, nil
+}
+
+func validateAutoscalerAllocationMode(mode string) error {
+	switch mode {
+	case allocationModeDevicePlugin, allocationModeDRA:
+		return nil
+	default:
+		return fmt.Errorf("supported values are %q and %q; automatic detection is not used because the target pool must be deterministic",
+			allocationModeDevicePlugin, allocationModeDRA)
+	}
+}
+
+func validateAutoscalerDurations(pending, scaleUp, scaleDown, stableFor time.Duration) error {
+	switch {
+	case pending <= 0:
+		return fmt.Errorf("-autoscaler-pending-timeout must be greater than zero")
+	case scaleUp <= 0:
+		return fmt.Errorf("-autoscaler-scale-up-timeout must be greater than zero")
+	case scaleDown <= 0:
+		return fmt.Errorf("-autoscaler-scale-down-timeout must be greater than zero")
+	case stableFor < 0:
+		return fmt.Errorf("-autoscaler-stability-window must not be negative")
+	case stableFor >= scaleDown:
+		return fmt.Errorf("-autoscaler-stability-window must be shorter than -autoscaler-scale-down-timeout")
+	default:
+		return nil
+	}
+}
+
+func createBaselinePDB(
+	ctx context.Context,
+	t *testing.T,
+	c kubernetes.Interface,
+	namespace, runLabelValue string,
+	baselineCount int,
+) {
+	t.Helper()
+	minAvailable := intstr.FromInt32(int32(baselineCount))
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "autoscaler-baseline", Namespace: namespace},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{autoscalerRunLabelKey: runLabelValue},
+			},
+		},
+	}
+	if _, err := c.PolicyV1().PodDisruptionBudgets(namespace).Create(ctx, pdb, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create baseline PodDisruptionBudget: %v", err)
+	}
+}
+
+func readyPoolNodes(ctx context.Context, c kubernetes.Interface, key, value string) (map[string]corev1.Node, error) {
+	nodes, err := labeledPoolNodes(ctx, c, key, value)
+	if err != nil {
+		return nil, err
+	}
+
+	ready := make(map[string]corev1.Node)
+	for name, node := range nodes {
+		if node.Spec.Unschedulable || !nodeIsReady(&node) {
+			continue
+		}
+		ready[name] = node
+	}
+	return ready, nil
+}
+
+func labeledPoolNodes(ctx context.Context, c kubernetes.Interface, key, value string) (map[string]corev1.Node, error) {
+	nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	matching := make(map[string]corev1.Node)
+	for _, node := range nodes.Items {
+		if node.Labels[key] == value {
+			matching[node.Name] = node
+		}
+	}
+	return matching, nil
+}
+
+func sameNodeIdentitySet(a, b map[string]corev1.Node) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, node := range a {
+		other, ok := b[name]
+		if !ok || node.UID != other.UID {
+			return false
+		}
+	}
+	return true
+}
+
+func waitForStablePoolSize(
+	ctx context.Context,
+	c kubernetes.Interface,
+	key, value string,
+	expected int,
+	stableFor, timeout time.Duration,
+) (map[string]corev1.Node, error) {
+	var stableSince time.Time
+	var stableNodes map[string]corev1.Node
+	var lastNodes map[string]corev1.Node
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		nodes, err := readyPoolNodes(ctx, c, key, value)
+		if err != nil {
+			lastAPIError = err
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		lastAPIError = nil
+		lastNodes = nodes
+		if len(nodes) != expected {
+			stableSince = time.Time{}
+			stableNodes = nil
+			return false, nil
+		}
+		if stableSince.IsZero() || !sameNodeIdentitySet(nodes, stableNodes) {
+			stableSince = time.Now()
+			stableNodes = nodes
+		}
+		return stableFor <= 0 || time.Since(stableSince) >= stableFor, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("wanted %d nodes stable for %s; last observed %d%s: %w",
+			expected, stableFor, len(lastNodes), lastAPIErrorSuffix(lastAPIError), err)
+	}
+	return lastNodes, nil
+}
+
+func verifyPoolDevicePluginCapacity(nodes map[string]corev1.Node, cfg AcceleratorConfig) error {
+	resourceName := corev1.ResourceName(cfg.ExtendedResource)
+	var invalid []string
+	for name, node := range nodes {
+		q, ok := node.Status.Allocatable[resourceName]
+		if !ok || q.Value() != 1 {
+			invalid = append(invalid, fmt.Sprintf("%s=%s", name, q.String()))
+		}
+	}
+	if len(invalid) > 0 {
+		sort.Strings(invalid)
+		return fmt.Errorf("pool nodes must each advertise exactly one allocatable %s: %s", resourceName, strings.Join(invalid, ", "))
+	}
+	return nil
+}
+
+func verifyAutoscalerPoolCapacity(
+	ctx context.Context,
+	c kubernetes.Interface,
+	nodes map[string]corev1.Node,
+	mode string,
+	cfg AcceleratorConfig,
+) error {
+	switch mode {
+	case allocationModeDevicePlugin:
+		if err := verifyPoolDevicePluginCapacity(nodes, cfg); err != nil {
+			return err
+		}
+		if err := checkExtendedResourceNotDRABacked(ctx, c, cfg); err != nil {
+			return fmt.Errorf("device-plugin allocation would not be deterministic: %w", err)
+		}
+		return nil
+	case allocationModeDRA:
+		if _, err := c.ResourceV1().DeviceClasses().Get(ctx, cfg.DeviceClass, metav1.GetOptions{}); err != nil {
+			return fmt.Errorf("DRA DeviceClass %s is not available: %w", cfg.DeviceClass, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown allocation mode %q", mode)
+	}
+}
+
+func verifyPoolIsIdle(
+	ctx context.Context,
+	c kubernetes.Interface,
+	testNamespace string,
+	poolNodes map[string]corev1.Node,
+	poolKey, poolValue, mode string,
+	cfg AcceleratorConfig,
+) error {
+	pods, err := c.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Pods while checking target-pool isolation: %w", err)
+	}
+
+	var foreign []string
+	if mode == allocationModeDRA {
+		claims, err := c.ResourceV1().ResourceClaims(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to list ResourceClaims while checking DRA isolation: %w", err)
+		}
+		for _, claim := range claims.Items {
+			if claim.Namespace != testNamespace && claim.Status.Allocation != nil {
+				foreign = append(foreign, fmt.Sprintf("%s/%s has an active DRA allocation", claim.Namespace, claim.Name))
+			}
+		}
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Namespace == testNamespace || pod.DeletionTimestamp != nil || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		if mode == allocationModeDRA && len(pod.Spec.ResourceClaims) > 0 {
+			location := "pending"
+			if pod.Spec.NodeName != "" {
+				location = "on " + pod.Spec.NodeName
+			}
+			foreign = append(foreign, fmt.Sprintf("%s/%s uses DRA claims %s", pod.Namespace, pod.Name, location))
+			continue
+		}
+		if isDaemonOrMirrorPod(pod) {
+			continue
+		}
+		if _, inPool := poolNodes[pod.Spec.NodeName]; inPool {
+			foreign = append(foreign, fmt.Sprintf("%s/%s on %s", pod.Namespace, pod.Name, pod.Spec.NodeName))
+			continue
+		}
+		if pod.Spec.NodeName == "" {
+			switch {
+			case pod.Spec.NodeSelector[poolKey] == poolValue:
+				foreign = append(foreign, fmt.Sprintf("%s/%s pending for the target pool", pod.Namespace, pod.Name))
+			case podRequestsAccelerator(pod, mode, cfg):
+				foreign = append(foreign, fmt.Sprintf("%s/%s pending for the configured accelerator", pod.Namespace, pod.Name))
+			}
+		}
+	}
+	if len(foreign) > 0 {
+		sort.Strings(foreign)
+		return fmt.Errorf("target accelerator pool is not isolated; found foreign workloads: %s", strings.Join(foreign, ", "))
+	}
+	return nil
+}
+
+func isDaemonOrMirrorPod(pod *corev1.Pod) bool {
+	if _, ok := pod.Annotations["kubernetes.io/config.mirror"]; ok {
+		return true
+	}
+	owner := metav1.GetControllerOf(pod)
+	return owner != nil && owner.Kind == "DaemonSet"
+}
+
+func podRequestsAccelerator(pod *corev1.Pod, mode string, cfg AcceleratorConfig) bool {
+	if mode == allocationModeDRA {
+		return len(pod.Spec.ResourceClaims) > 0
+	}
+	resourceName := corev1.ResourceName(cfg.ExtendedResource)
+	requestsAccelerator := func(containers []corev1.Container) bool {
+		for _, container := range containers {
+			request := container.Resources.Requests[resourceName]
+			limit := container.Resources.Limits[resourceName]
+			if !request.IsZero() || !limit.IsZero() {
+				return true
+			}
+		}
+		return false
+	}
+	return requestsAccelerator(pod.Spec.InitContainers) || requestsAccelerator(pod.Spec.Containers)
+}
+
+func buildAutoscalingPod(
+	namespace, name, runLabelValue, poolKey, poolValue, mode string,
+	cfg AcceleratorConfig,
+	requireDistinctNode bool,
+) (*corev1.Pod, error) {
+	pod, err := buildTestPod(
+		namespace,
+		name,
+		[]corev1.Container{{
+			Name:    "worker",
+			Image:   "ubuntu:22.04",
+			Command: []string{"/bin/sh", "-c"},
+			Args:    []string{"sleep 86400"},
+		}},
+		testPodConfig{grantAccelerator: true, mode: mode, cfg: cfg},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	pod.Spec.NodeSelector = map[string]string{poolKey: poolValue}
+	if requireDistinctNode {
+		pod.Labels = map[string]string{autoscalerRunLabelKey: runLabelValue}
+		pod.Spec.Affinity = &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{autoscalerRunLabelKey: runLabelValue},
+					},
+					TopologyKey: corev1.LabelHostname,
+				}},
+			},
+		}
+	}
+	return pod, nil
+}
+
+func verifyBaselinePlacement(pods map[string]*corev1.Pod, baselineNodes map[string]corev1.Node) error {
+	placements := make(map[string]string, len(pods))
+	for name, pod := range pods {
+		if _, ok := baselineNodes[pod.Spec.NodeName]; !ok {
+			return fmt.Errorf("baseline Pod %s ran on node %s outside the captured pool", name, pod.Spec.NodeName)
+		}
+		if other, exists := placements[pod.Spec.NodeName]; exists {
+			return fmt.Errorf("baseline Pods %s and %s ran on the same node %s; expected one Pod per pool node", other, name, pod.Spec.NodeName)
+		}
+		placements[pod.Spec.NodeName] = name
+	}
+	if len(placements) != len(baselineNodes) {
+		return fmt.Errorf("baseline Pods occupied %d distinct nodes, want %d", len(placements), len(baselineNodes))
+	}
+	return nil
+}
+
+func podUnschedulable(pod *corev1.Pod) (bool, string) {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == corev1.PodReasonUnschedulable {
+			return true, condition.Message
+		}
+	}
+	return false, ""
+}
+
+func waitForPodUnschedulable(
+	ctx context.Context,
+	c kubernetes.Interface,
+	namespace, name string,
+	timeout time.Duration,
+) (string, error) {
+	var lastPhase corev1.PodPhase
+	var lastMessage string
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			lastAPIError = err
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		lastAPIError = nil
+		lastPhase = pod.Status.Phase
+		if unschedulable, message := podUnschedulable(pod); unschedulable {
+			lastMessage = message
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("Pod %s remained in phase %s without an Unschedulable condition within %s%s: %w",
+			name, lastPhase, timeout, lastAPIErrorSuffix(lastAPIError), err)
+	}
+	return lastMessage, nil
+}
+
+func waitForTriggerRunningAfterScaleUp(
+	ctx context.Context,
+	c kubernetes.Interface,
+	namespace, podName, poolKey, poolValue string,
+	baselineNodes map[string]corev1.Node,
+	mode string,
+	cfg AcceleratorConfig,
+	timeout time.Duration,
+) (*corev1.Pod, map[string]corev1.Node, error) {
+	var lastNodes map[string]corev1.Node
+	var running *corev1.Pod
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		nodes, err := readyPoolNodes(ctx, c, poolKey, poolValue)
+		if err != nil {
+			lastAPIError = err
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		lastAPIError = nil
+		lastNodes = nodes
+		for name, baseline := range baselineNodes {
+			current, ok := nodes[name]
+			if !ok || current.UID != baseline.UID {
+				return false, fmt.Errorf("baseline node %s changed or stopped being Ready and schedulable during scale-up", name)
+			}
+		}
+		if err := verifyPoolIsIdle(ctx, c, namespace, nodes, poolKey, poolValue, mode, cfg); err != nil {
+			if isRetryableAPIError(err) {
+				lastAPIError = err
+				return false, nil
+			}
+			return false, err
+		}
+		if len(nodes) < len(baselineNodes)+1 {
+			return false, nil
+		}
+
+		pod, err := c.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			lastAPIError = err
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		lastAPIError = nil
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+		triggerNode, inPool := nodes[pod.Spec.NodeName]
+		if !inPool {
+			return false, fmt.Errorf("trigger Pod ran on node %s outside the selected accelerator pool", pod.Spec.NodeName)
+		}
+		if baseline, existed := baselineNodes[pod.Spec.NodeName]; existed && baseline.UID == triggerNode.UID {
+			return false, fmt.Errorf("trigger Pod ran on baseline node %s; accelerator capacity was not exhausted as required", pod.Spec.NodeName)
+		}
+		running = pod
+		return true, nil
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("last observed pool size %d, wanted at least %d and a Running trigger Pod%s: %w",
+			len(lastNodes), len(baselineNodes)+1, lastAPIErrorSuffix(lastAPIError), err)
+	}
+	return running, lastNodes, nil
+}
+
+func waitForScaleDown(
+	ctx context.Context,
+	c kubernetes.Interface,
+	poolKey, poolValue string,
+	scaledNode nodeReference,
+	baselineNodes map[string]corev1.Node,
+	stableFor, timeout time.Duration,
+) error {
+	var stableSince time.Time
+	var lastReadyCount int
+	var baselineUsable bool
+	var scaledNodeReady bool
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		nodes, err := labeledPoolNodes(ctx, c, poolKey, poolValue)
+		if err != nil {
+			lastAPIError = err
+			if isRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		lastAPIError = nil
+		lastReadyCount = 0
+		scaledNodeReady = false
+		for _, node := range nodes {
+			if !nodeIsReady(&node) {
+				continue
+			}
+			lastReadyCount++
+			if node.Name == scaledNode.name && node.UID == scaledNode.uid {
+				scaledNodeReady = true
+			}
+		}
+
+		baselineUsable = true
+		for name, baseline := range baselineNodes {
+			current, ok := nodes[name]
+			if !ok || current.UID != baseline.UID || current.Spec.Unschedulable || !nodeIsReady(&current) {
+				baselineUsable = false
+				break
+			}
+		}
+		if lastReadyCount != len(baselineNodes) || !baselineUsable || scaledNodeReady {
+			stableSince = time.Time{}
+			return false, nil
+		}
+		if stableSince.IsZero() {
+			stableSince = time.Now()
+		}
+		return stableFor <= 0 || time.Since(stableSince) >= stableFor, nil
+	})
+	if err != nil {
+		return fmt.Errorf("last observed Ready pool size %d; baseline Ready and schedulable=%t; scaled node %s/%s Ready=%t; wanted the %d baseline nodes Ready and schedulable for %s%s: %w",
+			lastReadyCount, baselineUsable, scaledNode.name, scaledNode.uid, scaledNodeReady, len(baselineNodes), stableFor, lastAPIErrorSuffix(lastAPIError), err)
+	}
+	return nil
+}

--- a/test/cluster_autoscaling_test.go
+++ b/test/cluster_autoscaling_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -20,10 +21,11 @@ import (
 )
 
 const (
-	autoscalerRunLabelKey    = "ai-conformance.kubernetes.io/autoscaler-run"
-	baselinePodTimeout       = 5 * time.Minute
-	baselineStabilityWindow  = 30 * time.Second
-	baselineStabilityTimeout = 2 * time.Minute
+	autoscalerRunLabelKey       = "ai-conformance.kubernetes.io/autoscaler-run"
+	baselinePodTimeout          = 5 * time.Minute
+	baselineStabilityWindow     = 30 * time.Second
+	baselineStabilityTimeout    = 2 * time.Minute
+	autoscalerPodDeadlineBuffer = 15 * time.Minute
 )
 
 type nodeReference struct {
@@ -76,6 +78,11 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	); err != nil {
 		t.Fatalf("Invalid autoscaler timeout configuration: %v", err)
 	}
+	podDeadlineSeconds := autoscalerPodDeadlineSeconds(
+		*autoscalerPendingTimeout,
+		*autoscalerScaleUpTimeout,
+		*autoscalerScaleDownTimeout,
+	)
 	cfg, err := lookupAcceleratorConfig(*acceleratorType)
 	if err != nil {
 		t.Fatalf("Invalid -accelerator-type: %v", err)
@@ -140,7 +147,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 	baselinePodNames := make([]string, 0, baselineCount)
 	for i := 0; i < baselineCount; i++ {
 		name := fmt.Sprintf("autoscaler-baseline-%d", i)
-		pod, err := buildAutoscalingPod(namespace, name, runLabelValue, poolKey, poolValue, mode, cfg, true)
+		pod, err := buildAutoscalingPod(namespace, name, runLabelValue, poolKey, poolValue, mode, cfg, podDeadlineSeconds, true)
 		if err != nil {
 			t.Fatalf("Failed to build baseline Pod %s: %v", name, err)
 		}
@@ -173,7 +180,7 @@ func TestAcceleratorClusterAutoscaling(t *testing.T) {
 
 	// Create one additional Pod and verify it initially cannot be scheduled.
 	triggerName := "autoscaler-trigger"
-	trigger, err := buildAutoscalingPod(namespace, triggerName, runLabelValue, poolKey, poolValue, mode, cfg, false)
+	trigger, err := buildAutoscalingPod(namespace, triggerName, runLabelValue, poolKey, poolValue, mode, cfg, podDeadlineSeconds, false)
 	if err != nil {
 		t.Fatalf("Failed to build scale-up trigger Pod: %v", err)
 	}
@@ -266,6 +273,11 @@ func validateAutoscalerDurations(pending, scaleUp, scaleDown, stableFor time.Dur
 	default:
 		return nil
 	}
+}
+
+func autoscalerPodDeadlineSeconds(pending, scaleUp, scaleDown time.Duration) int64 {
+	lifetime := baselinePodTimeout + pending + scaleUp + scaleDown + autoscalerPodDeadlineBuffer
+	return int64((lifetime + time.Second - 1) / time.Second)
 }
 
 func createBaselinePDB(
@@ -424,7 +436,9 @@ func verifyPoolIsIdle(
 	poolKey, poolValue, mode string,
 	cfg AcceleratorConfig,
 ) error {
-	pods, err := c.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	pods, err := c.CoreV1().Pods(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
+		FieldSelector: nonTerminalPodFieldSelector(),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to list Pods while checking target-pool isolation: %w", err)
 	}
@@ -477,6 +491,13 @@ func verifyPoolIsIdle(
 	return nil
 }
 
+func nonTerminalPodFieldSelector() string {
+	return fields.AndSelectors(
+		fields.OneTermNotEqualSelector("status.phase", string(corev1.PodSucceeded)),
+		fields.OneTermNotEqualSelector("status.phase", string(corev1.PodFailed)),
+	).String()
+}
+
 func isDaemonOrMirrorPod(pod *corev1.Pod) bool {
 	if _, ok := pod.Annotations["kubernetes.io/config.mirror"]; ok {
 		return true
@@ -506,6 +527,7 @@ func podRequestsAccelerator(pod *corev1.Pod, mode string, cfg AcceleratorConfig)
 func buildAutoscalingPod(
 	namespace, name, runLabelValue, poolKey, poolValue, mode string,
 	cfg AcceleratorConfig,
+	activeDeadlineSeconds int64,
 	requireDistinctNode bool,
 ) (*corev1.Pod, error) {
 	pod, err := buildTestPod(
@@ -515,7 +537,7 @@ func buildAutoscalingPod(
 			Name:    "worker",
 			Image:   "ubuntu:22.04",
 			Command: []string{"/bin/sh", "-c"},
-			Args:    []string{"sleep 86400"},
+			Args:    []string{"sleep infinity"},
 		}},
 		testPodConfig{grantAccelerator: true, mode: mode, cfg: cfg},
 	)
@@ -524,6 +546,7 @@ func buildAutoscalingPod(
 	}
 
 	pod.Spec.NodeSelector = map[string]string{poolKey: poolValue}
+	pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 	if requireDistinctNode {
 		pod.Labels = map[string]string{autoscalerRunLabelKey: runLabelValue}
 		pod.Spec.Affinity = &corev1.Affinity{

--- a/test/cluster_autoscaling_unit_test.go
+++ b/test/cluster_autoscaling_unit_test.go
@@ -1,0 +1,442 @@
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestParseNodePoolLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantKey   string
+		wantValue string
+		wantErr   string
+	}{
+		{
+			name:      "simple label",
+			input:     "agentpool=gpupool",
+			wantKey:   "agentpool",
+			wantValue: "gpupool",
+		},
+		{
+			name:      "qualified label",
+			input:     "cloud.google.com/gke-nodepool=gpu-pool",
+			wantKey:   "cloud.google.com/gke-nodepool",
+			wantValue: "gpu-pool",
+		},
+		{name: "empty", input: "", wantErr: "exactly one"},
+		{name: "missing equals", input: "agentpool", wantErr: "exactly one"},
+		{name: "multiple equals", input: "a=b=c", wantErr: "exactly one"},
+		{name: "empty key", input: "=value", wantErr: "non-empty"},
+		{name: "empty value", input: "key=", wantErr: "non-empty"},
+		{name: "invalid key", input: "bad key=value", wantErr: "invalid label key"},
+		{name: "invalid value", input: "key=bad/value", wantErr: "invalid label value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, value, err := parseNodePoolLabel(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseNodePoolLabel(%q) error = %v, want containing %q", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseNodePoolLabel(%q) unexpected error: %v", tt.input, err)
+			}
+			if key != tt.wantKey || value != tt.wantValue {
+				t.Fatalf("parseNodePoolLabel(%q) = %q, %q; want %q, %q", tt.input, key, value, tt.wantKey, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestValidateAutoscalerAllocationMode(t *testing.T) {
+	for _, mode := range []string{allocationModeDevicePlugin, allocationModeDRA} {
+		if err := validateAutoscalerAllocationMode(mode); err != nil {
+			t.Fatalf("validateAutoscalerAllocationMode(%q) unexpected error: %v", mode, err)
+		}
+	}
+	for _, mode := range []string{allocationModeAuto, "unknown"} {
+		if err := validateAutoscalerAllocationMode(mode); err == nil {
+			t.Fatalf("validateAutoscalerAllocationMode(%q) expected error", mode)
+		}
+	}
+}
+
+func TestValidateAutoscalerDurations(t *testing.T) {
+	valid := []time.Duration{time.Minute, time.Minute, 10 * time.Minute, 30 * time.Second}
+	if err := validateAutoscalerDurations(valid[0], valid[1], valid[2], valid[3]); err != nil {
+		t.Fatalf("validateAutoscalerDurations unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name                                string
+		pending, scaleUp, scaleDown, stable time.Duration
+	}{
+		{name: "zero pending timeout", scaleUp: time.Minute, scaleDown: time.Minute},
+		{name: "zero scale-up timeout", pending: time.Minute, scaleDown: time.Minute},
+		{name: "zero scale-down timeout", pending: time.Minute, scaleUp: time.Minute},
+		{name: "negative stability window", pending: time.Minute, scaleUp: time.Minute, scaleDown: time.Minute, stable: -time.Second},
+		{name: "stability window equals scale-down timeout", pending: time.Minute, scaleUp: time.Minute, scaleDown: time.Minute, stable: time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateAutoscalerDurations(tt.pending, tt.scaleUp, tt.scaleDown, tt.stable); err == nil {
+				t.Fatal("validateAutoscalerDurations expected error")
+			}
+		})
+	}
+}
+
+func TestBuildAutoscalingPod(t *testing.T) {
+	cfg := nvidiaConfig(t)
+
+	t.Run("device plugin", func(t *testing.T) {
+		pod, err := buildAutoscalingPod("ns", "pod", "run-1", "agentpool", "gpu", allocationModeDevicePlugin, cfg, true)
+		if err != nil {
+			t.Fatalf("buildAutoscalingPod unexpected error: %v", err)
+		}
+
+		if pod.Labels[autoscalerRunLabelKey] != "run-1" {
+			t.Fatalf("run label = %q, want run-1", pod.Labels[autoscalerRunLabelKey])
+		}
+		if pod.Spec.NodeSelector["agentpool"] != "gpu" {
+			t.Fatalf("node selector = %v, want agentpool=gpu", pod.Spec.NodeSelector)
+		}
+		resourceName := corev1.ResourceName(cfg.ExtendedResource)
+		if got := pod.Spec.Containers[0].Resources.Limits[resourceName]; got.Cmp(resource.MustParse("1")) != 0 {
+			t.Fatalf("accelerator limit = %s, want 1", got.String())
+		}
+		verifyAutoscalingAntiAffinity(t, pod, "run-1")
+	})
+
+	t.Run("DRA", func(t *testing.T) {
+		pod, err := buildAutoscalingPod("ns", "pod", "run-2", "agentpool", "gpu", allocationModeDRA, cfg, true)
+		if err != nil {
+			t.Fatalf("buildAutoscalingPod unexpected error: %v", err)
+		}
+
+		if len(pod.Spec.ResourceClaims) != 1 || pod.Spec.ResourceClaims[0].Name != "claim" {
+			t.Fatalf("Pod ResourceClaims = %v, want one claim", pod.Spec.ResourceClaims)
+		}
+		if len(pod.Spec.Containers[0].Resources.Claims) != 1 ||
+			pod.Spec.Containers[0].Resources.Claims[0].Name != "claim" {
+			t.Fatalf("container claims = %v, want one claim", pod.Spec.Containers[0].Resources.Claims)
+		}
+		verifyAutoscalingAntiAffinity(t, pod, "run-2")
+	})
+
+	t.Run("trigger omits anti-affinity", func(t *testing.T) {
+		pod, err := buildAutoscalingPod("ns", "pod", "run-3", "agentpool", "gpu", allocationModeDRA, cfg, false)
+		if err != nil {
+			t.Fatalf("buildAutoscalingPod unexpected error: %v", err)
+		}
+		if pod.Spec.Affinity != nil {
+			t.Fatalf("trigger affinity = %v, want nil", pod.Spec.Affinity)
+		}
+		if _, ok := pod.Labels[autoscalerRunLabelKey]; ok {
+			t.Fatalf("trigger labels = %v, want no autoscaler run label", pod.Labels)
+		}
+	})
+}
+
+func verifyAutoscalingAntiAffinity(t *testing.T, pod *corev1.Pod, runLabelValue string) {
+	t.Helper()
+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil {
+		t.Fatal("Pod anti-affinity is missing")
+	}
+	terms := pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 1 {
+		t.Fatalf("required anti-affinity terms = %d, want 1", len(terms))
+	}
+	if terms[0].TopologyKey != corev1.LabelHostname {
+		t.Fatalf("topology key = %q, want %q", terms[0].TopologyKey, corev1.LabelHostname)
+	}
+	if got := terms[0].LabelSelector.MatchLabels[autoscalerRunLabelKey]; got != runLabelValue {
+		t.Fatalf("anti-affinity run label = %q, want %q", got, runLabelValue)
+	}
+}
+
+func TestReadyPoolNodes(t *testing.T) {
+	matchingReady := gpuNode("matching-ready", 1, true, false)
+	matchingReady.Labels = map[string]string{"agentpool": "gpu"}
+	matchingNotReady := gpuNode("matching-not-ready", 1, false, false)
+	matchingNotReady.Labels = map[string]string{"agentpool": "gpu"}
+	matchingUnschedulable := gpuNode("matching-unschedulable", 1, true, true)
+	matchingUnschedulable.Labels = map[string]string{"agentpool": "gpu"}
+	otherPool := gpuNode("other-pool", 1, true, false)
+	otherPool.Labels = map[string]string{"agentpool": "cpu"}
+
+	client := fake.NewClientset(matchingReady, matchingNotReady, matchingUnschedulable, otherPool)
+	nodes, err := readyPoolNodes(context.Background(), client, "agentpool", "gpu")
+	if err != nil {
+		t.Fatalf("readyPoolNodes unexpected error: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("readyPoolNodes returned %d nodes, want 1: %v", len(nodes), nodes)
+	}
+	if _, ok := nodes["matching-ready"]; !ok {
+		t.Fatalf("readyPoolNodes = %v, want matching-ready", nodes)
+	}
+}
+
+func TestPodUnschedulable(t *testing.T) {
+	tests := []struct {
+		name        string
+		conditions  []corev1.PodCondition
+		want        bool
+		wantMessage string
+	}{
+		{name: "no conditions"},
+		{
+			name: "unschedulable",
+			conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionFalse,
+				Reason: corev1.PodReasonUnschedulable, Message: "0/1 nodes are available",
+			}},
+			want:        true,
+			wantMessage: "0/1 nodes are available",
+		},
+		{
+			name: "scheduled",
+			conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionTrue,
+			}},
+		},
+		{
+			name: "different reason",
+			conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: "SchedulingGated",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{Conditions: tt.conditions}}
+			got, message := podUnschedulable(pod)
+			if got != tt.want || message != tt.wantMessage {
+				t.Fatalf("podUnschedulable() = %v, %q; want %v, %q", got, message, tt.want, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestVerifyBaselinePlacement(t *testing.T) {
+	baseline := map[string]corev1.Node{
+		"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+		"node-b": {ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
+	}
+
+	t.Run("covers every baseline node", func(t *testing.T) {
+		pods := map[string]*corev1.Pod{
+			"pod-a": {ObjectMeta: metav1.ObjectMeta{Name: "pod-a"}, Spec: corev1.PodSpec{NodeName: "node-a"}},
+			"pod-b": {ObjectMeta: metav1.ObjectMeta{Name: "pod-b"}, Spec: corev1.PodSpec{NodeName: "node-b"}},
+		}
+		if err := verifyBaselinePlacement(pods, baseline); err != nil {
+			t.Fatalf("verifyBaselinePlacement unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects duplicate placement", func(t *testing.T) {
+		pods := map[string]*corev1.Pod{
+			"pod-a": {ObjectMeta: metav1.ObjectMeta{Name: "pod-a"}, Spec: corev1.PodSpec{NodeName: "node-a"}},
+			"pod-b": {ObjectMeta: metav1.ObjectMeta{Name: "pod-b"}, Spec: corev1.PodSpec{NodeName: "node-a"}},
+		}
+		if err := verifyBaselinePlacement(pods, baseline); err == nil {
+			t.Fatal("verifyBaselinePlacement expected duplicate-placement error")
+		}
+	})
+}
+
+func TestSameNodeIdentitySet(t *testing.T) {
+	original := map[string]corev1.Node{
+		"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("uid-a")}},
+	}
+	same := map[string]corev1.Node{
+		"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("uid-a")}},
+	}
+	replaced := map[string]corev1.Node{
+		"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("uid-b")}},
+	}
+	if !sameNodeIdentitySet(original, same) {
+		t.Fatal("sameNodeIdentitySet rejected the same node UID")
+	}
+	if sameNodeIdentitySet(original, replaced) {
+		t.Fatal("sameNodeIdentitySet accepted a replacement node with the same name")
+	}
+}
+
+func TestVerifyPoolIsIdle(t *testing.T) {
+	cfg := nvidiaConfig(t)
+	poolNode := labeledNode("node-a", map[string]string{"agentpool": "gpu"}, true)
+	poolNodes := map[string]corev1.Node{"node-a": *poolNode}
+
+	t.Run("ignores test and DaemonSet Pods", func(t *testing.T) {
+		controller := true
+		client := fake.NewClientset(
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "baseline", Namespace: "test"}, Spec: corev1.PodSpec{NodeName: "node-a"}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name: "daemon", Namespace: "system",
+				OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "daemon", Controller: &controller}},
+			}, Spec: corev1.PodSpec{NodeName: "node-a"}},
+		)
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDevicePlugin, cfg); err != nil {
+			t.Fatalf("verifyPoolIsIdle unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects a foreign scheduled Pod", func(t *testing.T) {
+		client := fake.NewClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "other"},
+			Spec:       corev1.PodSpec{NodeName: "node-a"},
+		})
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDevicePlugin, cfg); err == nil {
+			t.Fatal("verifyPoolIsIdle expected foreign-workload error")
+		}
+	})
+
+	t.Run("rejects foreign pending accelerator demand", func(t *testing.T) {
+		resourceName := corev1.ResourceName(cfg.ExtendedResource)
+		client := fake.NewClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: "other"},
+			Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{"agentpool": "gpu"},
+				Containers: []corev1.Container{{
+					Name: "worker",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{resourceName: resource.MustParse("1")},
+					},
+				}},
+			},
+		})
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDevicePlugin, cfg); err == nil {
+			t.Fatal("verifyPoolIsIdle expected pending-demand error")
+		}
+	})
+
+	t.Run("rejects other pending target-pool demand", func(t *testing.T) {
+		client := fake.NewClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "foreign-cpu", Namespace: "other"},
+			Spec: corev1.PodSpec{
+				NodeSelector: map[string]string{"agentpool": "gpu"},
+			},
+		})
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDevicePlugin, cfg); err == nil {
+			t.Fatal("verifyPoolIsIdle expected target-pool demand error")
+		}
+	})
+
+	t.Run("rejects foreign DRA claims outside the pool", func(t *testing.T) {
+		templateName := "foreign-template"
+		client := fake.NewClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "foreign-dra", Namespace: "other"},
+			Spec: corev1.PodSpec{
+				NodeName:       "other-node",
+				ResourceClaims: []corev1.PodResourceClaim{{Name: "gpu", ResourceClaimTemplateName: &templateName}},
+			},
+		})
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDRA, cfg); err == nil {
+			t.Fatal("verifyPoolIsIdle expected foreign DRA demand error")
+		}
+	})
+
+	t.Run("rejects allocated ResourceClaims outside the test namespace", func(t *testing.T) {
+		client := fake.NewClientset(claim("other", "allocated", true))
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDRA, cfg); err == nil {
+			t.Fatal("verifyPoolIsIdle expected foreign allocated-claim error")
+		}
+	})
+}
+
+func TestWaitForScaleDown(t *testing.T) {
+	baseline := gpuNode("baseline", 1, true, false)
+	baseline.UID = types.UID("baseline-uid")
+	baseline.Labels = map[string]string{"agentpool": "gpu"}
+	scaled := gpuNode("scaled", 1, false, false)
+	scaled.UID = types.UID("scaled-uid")
+	scaled.Labels = map[string]string{"agentpool": "gpu"}
+	baselineNodes := map[string]corev1.Node{baseline.Name: *baseline}
+	scaledRef := nodeReference{name: scaled.Name, uid: scaled.UID}
+
+	t.Run("accepts a retained NotReady Node object", func(t *testing.T) {
+		client := fake.NewClientset(baseline, scaled)
+		if err := waitForScaleDown(context.Background(), client, "agentpool", "gpu", scaledRef, baselineNodes, 0, time.Second); err != nil {
+			t.Fatalf("waitForScaleDown unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects a Ready scaled Node even when cordoned", func(t *testing.T) {
+		readyScaled := scaled.DeepCopy()
+		readyScaled.Status.Conditions[0].Status = corev1.ConditionTrue
+		readyScaled.Spec.Unschedulable = true
+		client := fake.NewClientset(baseline, readyScaled)
+		if err := waitForScaleDown(context.Background(), client, "agentpool", "gpu", scaledRef, baselineNodes, 0, 50*time.Millisecond); err == nil {
+			t.Fatal("waitForScaleDown expected Ready scaled Node to block scale-down")
+		}
+	})
+
+	t.Run("rejects baseline replacement", func(t *testing.T) {
+		replacement := baseline.DeepCopy()
+		replacement.UID = types.UID("replacement-uid")
+		client := fake.NewClientset(replacement, scaled)
+		if err := waitForScaleDown(context.Background(), client, "agentpool", "gpu", scaledRef, baselineNodes, 0, 50*time.Millisecond); err == nil {
+			t.Fatal("waitForScaleDown expected baseline replacement to block scale-down")
+		}
+	})
+
+	t.Run("rejects a cordoned baseline node", func(t *testing.T) {
+		cordoned := baseline.DeepCopy()
+		cordoned.Spec.Unschedulable = true
+		client := fake.NewClientset(cordoned, scaled)
+		if err := waitForScaleDown(context.Background(), client, "agentpool", "gpu", scaledRef, baselineNodes, 0, 50*time.Millisecond); err == nil {
+			t.Fatal("waitForScaleDown expected cordoned baseline node to block scale-down")
+		}
+	})
+
+	t.Run("rejects an additional Ready overshoot node", func(t *testing.T) {
+		extra := gpuNode("extra", 1, true, false)
+		extra.UID = types.UID("extra-uid")
+		extra.Labels = map[string]string{"agentpool": "gpu"}
+		client := fake.NewClientset(baseline, scaled, extra)
+		if err := waitForScaleDown(context.Background(), client, "agentpool", "gpu", scaledRef, baselineNodes, 0, 50*time.Millisecond); err == nil {
+			t.Fatal("waitForScaleDown expected extra Ready node to block scale-down")
+		}
+	})
+}
+
+func TestVerifyAutoscalerPoolCapacityRejectsDRABackedExtendedResource(t *testing.T) {
+	cfg := nvidiaConfig(t)
+	node := gpuNode("node-a", 1, true, false)
+	nodes := map[string]corev1.Node{node.Name: *node}
+	client := fake.NewClientset(extendedResourceDeviceClass("mapped", cfg.ExtendedResource))
+	if err := verifyAutoscalerPoolCapacity(context.Background(), client, nodes, allocationModeDevicePlugin, cfg); err == nil || !strings.Contains(err.Error(), "would not be deterministic") {
+		t.Fatalf("verifyAutoscalerPoolCapacity error = %v, want DRA-backed extended-resource rejection", err)
+	}
+}
+
+func TestCreateBaselinePDB(t *testing.T) {
+	client := fake.NewClientset()
+	createBaselinePDB(context.Background(), t, client, "ns", "run-1", 3)
+	pdb, err := client.PolicyV1().PodDisruptionBudgets("ns").Get(context.Background(), "autoscaler-baseline", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get created PodDisruptionBudget: %v", err)
+	}
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntValue() != 3 {
+		t.Fatalf("minAvailable = %v, want 3", pdb.Spec.MinAvailable)
+	}
+	if got := pdb.Spec.Selector.MatchLabels[autoscalerRunLabelKey]; got != "run-1" {
+		t.Fatalf("run label = %q, want run-1", got)
+	}
+}

--- a/test/cluster_autoscaling_unit_test.go
+++ b/test/cluster_autoscaling_unit_test.go
@@ -61,19 +61,6 @@ func TestParseNodePoolLabel(t *testing.T) {
 	}
 }
 
-func TestValidateAutoscalerAllocationMode(t *testing.T) {
-	for _, mode := range []string{allocationModeDevicePlugin, allocationModeDRA} {
-		if err := validateAutoscalerAllocationMode(mode); err != nil {
-			t.Fatalf("validateAutoscalerAllocationMode(%q) unexpected error: %v", mode, err)
-		}
-	}
-	for _, mode := range []string{allocationModeAuto, "unknown"} {
-		if err := validateAutoscalerAllocationMode(mode); err == nil {
-			t.Fatalf("validateAutoscalerAllocationMode(%q) expected error", mode)
-		}
-	}
-}
-
 func TestValidateAutoscalerDurations(t *testing.T) {
 	valid := []time.Duration{time.Minute, time.Minute, 10 * time.Minute, 30 * time.Second}
 	if err := validateAutoscalerDurations(valid[0], valid[1], valid[2], valid[3]); err != nil {

--- a/test/cluster_autoscaling_unit_test.go
+++ b/test/cluster_autoscaling_unit_test.go
@@ -9,8 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestParseNodePoolLabel(t *testing.T) {
@@ -86,11 +88,22 @@ func TestValidateAutoscalerDurations(t *testing.T) {
 	}
 }
 
+func TestAutoscalerPodDeadlineSeconds(t *testing.T) {
+	pending := 1500 * time.Millisecond
+	scaleUp := 2500 * time.Millisecond
+	scaleDown := 3500 * time.Millisecond
+	want := int64((baselinePodTimeout + pending + scaleUp + scaleDown + autoscalerPodDeadlineBuffer + time.Second - 1) / time.Second)
+	if got := autoscalerPodDeadlineSeconds(pending, scaleUp, scaleDown); got != want {
+		t.Fatalf("autoscalerPodDeadlineSeconds = %d, want %d", got, want)
+	}
+}
+
 func TestBuildAutoscalingPod(t *testing.T) {
 	cfg := nvidiaConfig(t)
+	const deadlineSeconds int64 = 7200
 
 	t.Run("device plugin", func(t *testing.T) {
-		pod, err := buildAutoscalingPod("ns", "pod", "run-1", "agentpool", "gpu", allocationModeDevicePlugin, cfg, true)
+		pod, err := buildAutoscalingPod("ns", "pod", "run-1", "agentpool", "gpu", allocationModeDevicePlugin, cfg, deadlineSeconds, true)
 		if err != nil {
 			t.Fatalf("buildAutoscalingPod unexpected error: %v", err)
 		}
@@ -105,11 +118,12 @@ func TestBuildAutoscalingPod(t *testing.T) {
 		if got := pod.Spec.Containers[0].Resources.Limits[resourceName]; got.Cmp(resource.MustParse("1")) != 0 {
 			t.Fatalf("accelerator limit = %s, want 1", got.String())
 		}
+		verifyAutoscalingPodLifetime(t, pod, deadlineSeconds)
 		verifyAutoscalingAntiAffinity(t, pod, "run-1")
 	})
 
 	t.Run("DRA", func(t *testing.T) {
-		pod, err := buildAutoscalingPod("ns", "pod", "run-2", "agentpool", "gpu", allocationModeDRA, cfg, true)
+		pod, err := buildAutoscalingPod("ns", "pod", "run-2", "agentpool", "gpu", allocationModeDRA, cfg, deadlineSeconds, true)
 		if err != nil {
 			t.Fatalf("buildAutoscalingPod unexpected error: %v", err)
 		}
@@ -121,11 +135,12 @@ func TestBuildAutoscalingPod(t *testing.T) {
 			pod.Spec.Containers[0].Resources.Claims[0].Name != "claim" {
 			t.Fatalf("container claims = %v, want one claim", pod.Spec.Containers[0].Resources.Claims)
 		}
+		verifyAutoscalingPodLifetime(t, pod, deadlineSeconds)
 		verifyAutoscalingAntiAffinity(t, pod, "run-2")
 	})
 
 	t.Run("trigger omits anti-affinity", func(t *testing.T) {
-		pod, err := buildAutoscalingPod("ns", "pod", "run-3", "agentpool", "gpu", allocationModeDRA, cfg, false)
+		pod, err := buildAutoscalingPod("ns", "pod", "run-3", "agentpool", "gpu", allocationModeDRA, cfg, deadlineSeconds, false)
 		if err != nil {
 			t.Fatalf("buildAutoscalingPod unexpected error: %v", err)
 		}
@@ -135,7 +150,18 @@ func TestBuildAutoscalingPod(t *testing.T) {
 		if _, ok := pod.Labels[autoscalerRunLabelKey]; ok {
 			t.Fatalf("trigger labels = %v, want no autoscaler run label", pod.Labels)
 		}
+		verifyAutoscalingPodLifetime(t, pod, deadlineSeconds)
 	})
+}
+
+func verifyAutoscalingPodLifetime(t *testing.T, pod *corev1.Pod, wantDeadlineSeconds int64) {
+	t.Helper()
+	if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds != wantDeadlineSeconds {
+		t.Fatalf("active deadline seconds = %v, want %d", pod.Spec.ActiveDeadlineSeconds, wantDeadlineSeconds)
+	}
+	if got := pod.Spec.Containers[0].Args; len(got) != 1 || got[0] != "sleep infinity" {
+		t.Fatalf("container args = %v, want [sleep infinity]", got)
+	}
 }
 
 func verifyAutoscalingAntiAffinity(t *testing.T, pod *corev1.Pod, runLabelValue string) {
@@ -269,6 +295,28 @@ func TestVerifyPoolIsIdle(t *testing.T) {
 	cfg := nvidiaConfig(t)
 	poolNode := labeledNode("node-a", map[string]string{"agentpool": "gpu"}, true)
 	poolNodes := map[string]corev1.Node{"node-a": *poolNode}
+
+	t.Run("filters terminal Pods at the API server", func(t *testing.T) {
+		client := fake.NewClientset()
+		if err := verifyPoolIsIdle(context.Background(), client, "test", poolNodes, "agentpool", "gpu", allocationModeDevicePlugin, cfg); err != nil {
+			t.Fatalf("verifyPoolIsIdle unexpected error: %v", err)
+		}
+		actions := client.Actions()
+		if len(actions) != 1 {
+			t.Fatalf("client actions = %d, want 1", len(actions))
+		}
+		listAction, ok := actions[0].(k8stesting.ListAction)
+		if !ok {
+			t.Fatalf("client action = %T, want ListAction", actions[0])
+		}
+		wantSelector, err := fields.ParseSelector(nonTerminalPodFieldSelector())
+		if err != nil {
+			t.Fatalf("parse expected Pod field selector: %v", err)
+		}
+		if got, want := listAction.GetListRestrictions().Fields.String(), wantSelector.String(); got != want {
+			t.Fatalf("Pod field selector = %q, want %q", got, want)
+		}
+	})
 
 	t.Run("ignores test and DaemonSet Pods", func(t *testing.T) {
 		controller := true

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -2,6 +2,7 @@ package conformance
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"sort"
@@ -14,10 +15,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 )
 
@@ -90,6 +93,7 @@ func init() {
 // getClientset creates a Kubernetes clientset using the kubeconfig flag.
 // Shared helper to avoid duplicating kubeconfig loading across test files.
 func getClientset(t *testing.T) kubernetes.Interface {
+	t.Helper()
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if *kubeconfig != "" {
 		loadingRules.ExplicitPath = *kubeconfig
@@ -103,6 +107,49 @@ func getClientset(t *testing.T) kubernetes.Interface {
 		t.Fatalf("Error creating kubernetes client: %v", err)
 	}
 	return clientset
+}
+
+func deleteNamespaceAndWait(ctx context.Context, t *testing.T, c kubernetes.Interface, namespace string) error {
+	t.Helper()
+	t.Logf("Cleaning up namespace %s...", namespace)
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := c.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
+		switch {
+		case err == nil, apierrors.IsNotFound(err):
+			lastAPIError = nil
+			return true, nil
+		case isRetryableAPIError(err):
+			lastAPIError = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to request deletion of namespace %s%s: %w", namespace, lastAPIErrorSuffix(lastAPIError), err)
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := c.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			lastAPIError = nil
+			return true, nil
+		case err == nil:
+			lastAPIError = nil
+			return false, nil
+		case isRetryableAPIError(err):
+			lastAPIError = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("namespace %s was not deleted before the cleanup deadline%s: %w", namespace, lastAPIErrorSuffix(lastAPIError), err)
+	}
+	return nil
 }
 
 // lookupAcceleratorConfig resolves an -accelerator-type value to its config,
@@ -243,12 +290,17 @@ func usableNodes(ctx context.Context, c kubernetes.Interface) (map[string]corev1
 	}
 	usable := make(map[string]corev1.Node)
 	for _, node := range nodes.Items {
-		if node.Spec.Unschedulable || !isNodeReady(&node) {
+		if node.Spec.Unschedulable || !nodeIsReady(&node) {
 			continue
 		}
 		usable[node.Name] = node
 	}
 	return usable, nil
+}
+
+func nodeIsReady(node *corev1.Node) bool {
+	_, ready := nodeutil.GetNodeCondition(&node.Status, corev1.NodeReady)
+	return ready != nil && ready.Status == corev1.ConditionTrue
 }
 
 // checkDRAUsable verifies that DRA is usable for the accelerator under test:
@@ -487,15 +539,6 @@ func checkExtendedResourceNotDRABacked(ctx context.Context, c kubernetes.Interfa
 	return nil
 }
 
-func isNodeReady(node *corev1.Node) bool {
-	for _, cond := range node.Status.Conditions {
-		if cond.Type == corev1.NodeReady {
-			return cond.Status == corev1.ConditionTrue
-		}
-	}
-	return false
-}
-
 // testPodConfig controls how buildTestPod grants accelerators.
 type testPodConfig struct {
 	// grantAccelerator grants the FIRST container one accelerator using mode.
@@ -544,6 +587,50 @@ func buildTestPod(ns, name string, containers []corev1.Container, pc testPodConf
 	return pod, nil
 }
 
+func createTestPod(ctx context.Context, t *testing.T, c kubernetes.Interface, pod *corev1.Pod) {
+	t.Helper()
+	if _, err := c.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Pod %s: %v", pod.Name, err)
+	}
+}
+
+// waitForPodsRunning waits until every named Pod reaches Running and returns
+// their latest objects. This is shared by tests that coordinate multiple Pods.
+func waitForPodsRunning(
+	ctx context.Context,
+	c kubernetes.Interface,
+	namespace string,
+	names []string,
+	timeout time.Duration,
+) (map[string]*corev1.Pod, error) {
+	running := make(map[string]*corev1.Pod, len(names))
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		clear(running)
+		for _, name := range names {
+			pod, err := c.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				lastAPIError = err
+				if isRetryableAPIError(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			lastAPIError = nil
+			if pod.Status.Phase != corev1.PodRunning {
+				return false, nil
+			}
+			running[name] = pod
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Pods did not all reach Running within %s%s: %w",
+			timeout, lastAPIErrorSuffix(lastAPIError), err)
+	}
+	return running, nil
+}
+
 // runTestPod creates the pod described by pc, waits for it to reach Running,
 // and returns the running pod (so callers can read its scheduled node).
 func runTestPod(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, name string, containers []corev1.Container, pc testPodConfig) *corev1.Pod {
@@ -552,24 +639,10 @@ func runTestPod(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, n
 		t.Fatalf("Failed to build Pod %s: %v", name, err)
 	}
 
-	if _, err := c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Pod: %v", err)
-	}
+	createTestPod(ctx, t, c, pod)
 
 	t.Logf("Waiting for Pod %s to be running...", name)
-	var running *corev1.Pod
-	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-		p, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if p.Status.Phase == corev1.PodRunning {
-			running = p
-			return true, nil
-		}
-		return false, nil
-	})
-
+	running, err := waitForPodsRunning(ctx, c, ns, []string{name}, time.Minute)
 	if err != nil {
 		phase := "unknown"
 		if p, gerr := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{}); gerr == nil {
@@ -577,7 +650,7 @@ func runTestPod(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, n
 		}
 		t.Fatalf("Pod %s failed to reach Running phase within 1m. Current phase: %s, Error: %v", name, phase, err)
 	}
-	return running
+	return running[name]
 }
 
 // deletePodAndWait deletes a pod and waits until the pod AND any
@@ -587,15 +660,17 @@ func runTestPod(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, n
 // garbage-collected asynchronously after pod deletion). known is the pod as
 // last observed by the caller (may be nil) — it supplies the generated claim
 // names when the live pod can no longer be fetched.
-func deletePodAndWait(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, name string, known *corev1.Pod) {
-	claimNames, err := podGeneratedClaims(ctx, c, ns, name, known)
-	if err != nil {
-		// Claim capture failed but deletion must still proceed.
-		t.Errorf("Failed to capture generated ResourceClaims of Pod %s (claim-release wait may be incomplete): %v", name, err)
+func deletePodAndWait(ctx context.Context, c kubernetes.Interface, ns, name string, known *corev1.Pod) error {
+	claimNames, captureErr := podGeneratedClaims(ctx, c, ns, name, known)
+	releaseErr := deleteAndAwaitRelease(ctx, c, ns, name, claimNames)
+	if releaseErr == nil {
+		return nil
 	}
-	if err := deleteAndAwaitRelease(ctx, c, ns, name, claimNames); err != nil {
-		t.Errorf("Cleanup of Pod %s incomplete; subsequent accelerator tests may race its device/claim release: %v", name, err)
+	if captureErr != nil {
+		captureErr = fmt.Errorf("failed to capture generated ResourceClaims of Pod %s: %w", name, captureErr)
 	}
+	releaseErr = fmt.Errorf("cleanup of Pod %s incomplete: %w", name, releaseErr)
+	return errors.Join(captureErr, releaseErr)
 }
 
 // podGeneratedClaims returns the names of template-generated ResourceClaims
@@ -668,20 +743,48 @@ func podOwnedClaims(ctx context.Context, c kubernetes.Interface, ns, podName str
 // gone — generated claims are garbage-collected asynchronously and may
 // outlive the pod.
 func deleteAndAwaitRelease(ctx context.Context, c kubernetes.Interface, ns, name string, claimNames []string) error {
-	err := c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete pod: %w", err)
+	var podAlreadyGone bool
+	var lastAPIError error
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		err := c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
+		switch {
+		case err == nil:
+			lastAPIError = nil
+			return true, nil
+		case apierrors.IsNotFound(err):
+			lastAPIError = nil
+			podAlreadyGone = true
+			return true, nil
+		case isRetryableAPIError(err):
+			lastAPIError = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete pod%s: %w", lastAPIErrorSuffix(lastAPIError), err)
 	}
-	if err == nil {
+	if !podAlreadyGone {
+		var lastAPIError error
 		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			_, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
+			switch {
+			case apierrors.IsNotFound(err):
+				lastAPIError = nil
 				return true, nil
+			case err == nil:
+				lastAPIError = nil
+				return false, nil
+			case isRetryableAPIError(err):
+				lastAPIError = err
+				return false, nil
+			default:
+				return false, err
 			}
-			return false, err
 		})
 		if err != nil {
-			return fmt.Errorf("pod not deleted before the cleanup deadline: %w", err)
+			return fmt.Errorf("pod not deleted before the cleanup deadline%s: %w", lastAPIErrorSuffix(lastAPIError), err)
 		}
 	}
 
@@ -707,20 +810,27 @@ func deleteAndAwaitRelease(ctx context.Context, c kubernetes.Interface, ns, name
 	}
 
 	for _, claimName := range claimNames {
+		var lastAPIError error
 		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			claim, err := c.ResourceV1().ResourceClaims(ns).Get(ctx, claimName, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
+			switch {
+			case apierrors.IsNotFound(err):
+				lastAPIError = nil
 				return true, nil
-			}
-			if err != nil {
+			case err != nil && isRetryableAPIError(err):
+				lastAPIError = err
+				return false, nil
+			case err != nil:
 				return false, err
 			}
+			lastAPIError = nil
 			// A deallocated claim no longer holds devices even if the object
 			// briefly outlives the pod before garbage collection.
 			return claim.Status.Allocation == nil, nil
 		})
 		if err != nil {
-			return fmt.Errorf("generated ResourceClaim %s not released before the cleanup deadline: %w", claimName, err)
+			return fmt.Errorf("generated ResourceClaim %s not released before the cleanup deadline%s: %w",
+				claimName, lastAPIErrorSuffix(lastAPIError), err)
 		}
 	}
 	return nil
@@ -786,4 +896,22 @@ func acceleratorProbingContainer(name string, cfg AcceleratorConfig) corev1.Cont
 
 func randomNamespaceName(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, rand.String(5))
+}
+
+func lastAPIErrorSuffix(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("; last API error: %v", err)
+}
+
+func isRetryableAPIError(err error) bool {
+	return apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		utilnet.IsProbableEOF(err) ||
+		utilnet.IsConnectionReset(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
 }


### PR DESCRIPTION
Adds automated conformance coverage for KAR-0055, Effective Cluster Autoscaling for Accelerators.

The test creates one accelerator Pod per baseline node, verifies an additional Pod becomes Unschedulable, and confirms that the selected pool gains Ready capacity and schedules the Pod on a new Node. After deleting the trigger Pod, it verifies that the pool returns to its original Ready, schedulable size.

## What this adds

- Support for device-plugin and DRA allocation modes
- Provider-supplied node-pool identification
- Node UID tracking and stable baseline validation
- Detection of competing workloads and unrelated scaling demand
- Baseline Pod protection with a PodDisruptionBudget
- Portable scale-down checks that do not require Node object deletion
- Transient Kubernetes API retries and DRA claim cleanup
- Hermetic unit tests and updated documentation

## Environment contract

The test requires an isolated accelerator pool with:

- Minimum size `N >= 1` and maximum size of at least `N+1`
- A stable label inherited by newly created nodes
- Effective capacity for one accelerator allocation per baseline node
- Scale-down enabled and sufficient provider quota
- No competing workloads or Pending demand that could independently scale the pool

The test is skipped unless `-autoscaler-node-pool-label` is explicitly provided, preventing default test runs from creating cloud resources.

Ref: #55