### PR TITLE
Verify exact accelerator device count

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -19,10 +19,10 @@ go test -v ./test [-run <TestName>] [-kubeconfig=<path/to/kubeconfig>] [-acceler
 
 Run `go test ./test -args -help` for details about each flag.
 
-The allocation-mode detection and pod-construction logic also has hermetic unit tests (fake clientset, no cluster needed):
+The allocation-mode detection, pod-construction, and device-probe logic also has hermetic unit tests that need no cluster (Kubernetes API tests use a fake clientset):
 
 ```bash
-go test -v ./test -run 'Test(DetectAllocationMode|ExtendedResourceGuardFailsClosed|LookupAcceleratorConfig|BuildTestPod|PodGeneratedClaims|DeleteAndAwaitRelease)$'
+go test -v ./test -run 'Test(DetectAllocationMode|ExtendedResourceGuardFailsClosed|LookupAcceleratorConfig|BuildTestPod|PodGeneratedClaims|DeleteAndAwaitRelease|AcceleratorProbeCommand|LogsContainExactLine)$'
 ```
 
 ### Test Cases Covered

--- a/test/ai_conformance_test.go
+++ b/test/ai_conformance_test.go
@@ -80,7 +80,7 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 	// t.Parallel), so the refinement is ordered before its use.
 	acceleratorNode := env.acceleratorNode
 
-	// Getting an accelerator from inside a Pod that requests an accelerator should succeed
+	// A container that requests one accelerator should see exactly one.
 	t.Run("PositiveAccessTest", func(t *testing.T) {
 		podName := "pos-pod"
 		var pod *corev1.Pod
@@ -90,10 +90,10 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		pod = runTestPod(ctx, t, clientset, namespace, podName, []corev1.Container{acceleratorProbingContainer("prober", cfg)},
 			testPodConfig{grantAccelerator: true, mode: mode, cfg: cfg})
 		acceleratorNode = pod.Spec.NodeName
-		verifyHardwareInLogs(ctx, t, clientset, namespace, podName, "prober", true)
+		verifyAcceleratorCountInLogs(ctx, t, clientset, namespace, podName, "prober", requestedAcceleratorCount)
 	})
 
-	// Getting an accelerator from inside a Pod that does not request an accelerator should fail.
+	// A container that does not request an accelerator should see none.
 	// The pod is pinned to the accelerator node the positive pod ran on — an
 	// unpinned request-less pod could schedule onto a CPU-only node and pass
 	// vacuously without proving isolation.
@@ -112,10 +112,10 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		})
 		pod = runTestPod(ctx, t, clientset, namespace, podName, []corev1.Container{acceleratorProbingContainer("prober", cfg)},
 			testPodConfig{grantAccelerator: false, mode: mode, nodeName: acceleratorNode, cfg: cfg})
-		verifyHardwareInLogs(ctx, t, clientset, namespace, podName, "prober", false)
+		verifyAcceleratorCountInLogs(ctx, t, clientset, namespace, podName, "prober", 0)
 	})
 
-	// Getting an accelerator from another container inside a Pod should fail
+	// An accelerator granted to one container must not be visible to another.
 	t.Run("MultiContainerIsolationTest", func(t *testing.T) {
 		podName := "multi-container-pod"
 		var pod *corev1.Pod
@@ -125,8 +125,8 @@ func TestSecureAcceleratorAccess(t *testing.T) {
 		pod = runTestPod(ctx, t, clientset, namespace, podName, []corev1.Container{acceleratorProbingContainer("authorized", cfg), acceleratorProbingContainer("unauthorized", cfg)},
 			testPodConfig{grantAccelerator: true, mode: mode, cfg: cfg})
 
-		// The first container can access the accelerator, the second cannot
-		verifyHardwareInLogs(ctx, t, clientset, namespace, podName, "authorized", true)
-		verifyHardwareInLogs(ctx, t, clientset, namespace, podName, "unauthorized", false)
+		// The first container sees exactly the requested count; the second sees none.
+		verifyAcceleratorCountInLogs(ctx, t, clientset, namespace, podName, "authorized", requestedAcceleratorCount)
+		verifyAcceleratorCountInLogs(ctx, t, clientset, namespace, podName, "unauthorized", 0)
 	})
 }

--- a/test/device_probe_test.go
+++ b/test/device_probe_test.go
@@ -1,0 +1,62 @@
+package conformance
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAcceleratorProbeCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfg := nvidiaConfig(t)
+	for _, name := range []string{"nvidia0", "nvidia1", "nvidiactl", "nvidia-uvm"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatalf("create test device entry %s: %v", name, err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "nvidia-caps"), 0o700); err != nil {
+		t.Fatalf("create test control-device directory: %v", err)
+	}
+
+	pattern := filepath.Join(dir, filepath.Base(cfg.DevicePattern))
+	output, err := exec.Command("/bin/sh", "-c", acceleratorProbeCommand(pattern)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run accelerator probe: %v: %s", err, output)
+	}
+	if got, want := strings.TrimSpace(string(output)), "RESULT: ACCELERATOR_COUNT=2"; got != want {
+		t.Fatalf("probe output = %q, want %q", got, want)
+	}
+
+	emptyPattern := filepath.Join(dir, "missing[0-9]*")
+	output, err = exec.Command("/bin/sh", "-c", acceleratorProbeCommand(emptyPattern)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run empty accelerator probe: %v: %s", err, output)
+	}
+	if got, want := strings.TrimSpace(string(output)), "RESULT: ACCELERATOR_COUNT=0"; got != want {
+		t.Fatalf("empty probe output = %q, want %q", got, want)
+	}
+}
+
+func TestLogsContainExactLine(t *testing.T) {
+	tests := []struct {
+		name string
+		logs string
+		want bool
+	}{
+		{name: "exact count", logs: "setup complete\nRESULT: ACCELERATOR_COUNT=1\n", want: true},
+		{name: "surrounding whitespace", logs: "  RESULT: ACCELERATOR_COUNT=1  \n", want: true},
+		{name: "over-allocation is not a substring match", logs: "RESULT: ACCELERATOR_COUNT=10\n", want: false},
+		{name: "different count", logs: "RESULT: ACCELERATOR_COUNT=0\n", want: false},
+		{name: "missing result", logs: "setup complete\n", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := logsContainExactLine(tt.logs, "RESULT: ACCELERATOR_COUNT=1"); got != tt.want {
+				t.Errorf("logsContainExactLine() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/device_probe_test.go
+++ b/test/device_probe_test.go
@@ -20,22 +20,31 @@ func TestAcceleratorProbeCommand(t *testing.T) {
 		t.Fatalf("create test control-device directory: %v", err)
 	}
 
-	pattern := filepath.Join(dir, filepath.Base(cfg.DevicePattern))
-	output, err := exec.Command("/bin/sh", "-c", acceleratorProbeCommand(pattern)).CombinedOutput()
-	if err != nil {
-		t.Fatalf("run accelerator probe: %v: %s", err, output)
-	}
-	if got, want := strings.TrimSpace(string(output)), "RESULT: ACCELERATOR_COUNT=2"; got != want {
-		t.Fatalf("probe output = %q, want %q", got, want)
-	}
-
-	emptyPattern := filepath.Join(dir, "missing[0-9]*")
-	output, err = exec.Command("/bin/sh", "-c", acceleratorProbeCommand(emptyPattern)).CombinedOutput()
-	if err != nil {
-		t.Fatalf("run empty accelerator probe: %v: %s", err, output)
-	}
-	if got, want := strings.TrimSpace(string(output)), "RESULT: ACCELERATOR_COUNT=0"; got != want {
-		t.Fatalf("empty probe output = %q, want %q", got, want)
+	for _, tc := range []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{
+			name:    "counts matching device nodes",
+			pattern: filepath.Join(dir, filepath.Base(cfg.DevicePattern)),
+			want:    "RESULT: ACCELERATOR_COUNT=2",
+		},
+		{
+			name:    "no matching device nodes",
+			pattern: filepath.Join(dir, "missing[0-9]*"),
+			want:    "RESULT: ACCELERATOR_COUNT=0",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := exec.Command("/bin/sh", "-c", acceleratorProbeCommand(tc.pattern)).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run accelerator probe: %v: %s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != tc.want {
+				t.Errorf("probe output = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +19,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
-
 )
 
 type AcceleratorConfig struct {
@@ -39,32 +37,36 @@ type AcceleratorConfig struct {
 	// accelerators.
 	ExtendedResource string
 	TaintKey         string
-	DevicePath       string
+	// DevicePattern is a shell glob that matches allocatable accelerator
+	// device nodes while excluding auxiliary and control devices.
+	DevicePattern string
 }
 
 // Allocation modes for granting accelerators to test pods. The conformance
 // requirement permits mediation by "device plugin or DRA", so both mechanisms
 // are supported.
 const (
-	allocationModeAuto         = "auto"
-	allocationModeDRA          = "dra"
-	allocationModeDevicePlugin = "device-plugin"
+	allocationModeAuto                 = "auto"
+	allocationModeDRA                  = "dra"
+	allocationModeDevicePlugin         = "device-plugin"
+	requestedAcceleratorCount    int64 = 1
+	acceleratorCountResultPrefix       = "RESULT: ACCELERATOR_COUNT="
 )
 
 var (
-	kubeconfig         *string
-	acceleratorType    *string
-	allocationMode             *string
-	gangSchedulerNamespace     *string
-	gangJobLabels              *string
-	gangNegativeWindow         *time.Duration
-	acceleratorConfigs         = map[string]AcceleratorConfig{
+	kubeconfig             *string
+	acceleratorType        *string
+	allocationMode         *string
+	gangSchedulerNamespace *string
+	gangJobLabels          *string
+	gangNegativeWindow     *time.Duration
+	acceleratorConfigs     = map[string]AcceleratorConfig{
 		"nvidia": {
 			DeviceClass:      "gpu.nvidia.com",
 			DRADriver:        "gpu.nvidia.com",
 			ExtendedResource: "nvidia.com/gpu",
 			TaintKey:         "nvidia.com/gpu",
-			DevicePath:       "/dev/nvidia*",
+			DevicePattern:    "/dev/nvidia[0-9]*",
 		},
 		// Add other vendors here
 	}
@@ -138,7 +140,7 @@ func setupTestEnvironment(ctx context.Context, t *testing.T, c kubernetes.Interf
 						Name: testRequestName,
 						Exactly: &resourcev1.ExactDeviceRequest{
 							DeviceClassName: cfg.DeviceClass,
-							Count:           1,
+							Count:           requestedAcceleratorCount,
 						},
 					}},
 				},
@@ -533,7 +535,7 @@ func buildTestPod(ns, name string, containers []corev1.Container, pc testPodConf
 			if pod.Spec.Containers[0].Resources.Limits == nil {
 				pod.Spec.Containers[0].Resources.Limits = corev1.ResourceList{}
 			}
-			pod.Spec.Containers[0].Resources.Limits[resourceName] = resource.MustParse("1")
+			pod.Spec.Containers[0].Resources.Limits[resourceName] = *resource.NewQuantity(requestedAcceleratorCount, resource.DecimalSI)
 		default:
 			return nil, fmt.Errorf("unknown allocation mode %q", pc.mode)
 		}
@@ -724,22 +726,18 @@ func deleteAndAwaitRelease(ctx context.Context, c kubernetes.Interface, ns, name
 	return nil
 }
 
-// Verify that the container has access to the hardware (e.g. GPU) by checking its logs
-func verifyHardwareInLogs(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, podName, containerName string, expectSuccess bool) {
+// Verify that the container sees exactly the expected number of accelerator
+// device nodes by checking its logs.
+func verifyAcceleratorCountInLogs(ctx context.Context, t *testing.T, c kubernetes.Interface, ns, podName, containerName string, expectedCount int64) {
 	var logs string
 	pass := false
-	var expectedText string
-	if expectSuccess {
-		expectedText = "RESULT: ACCELERATOR_FOUND"
-	} else {
-		expectedText = "RESULT: ACCELERATOR_MISSING"
-	}
+	expectedText := fmt.Sprintf("%s%d", acceleratorCountResultPrefix, expectedCount)
 	t.Logf("Waiting to see if Pod %s/%s logs contain '%s'...", podName, containerName, expectedText)
 	for i := 0; i < 2; i++ {
 		rawLogs, err := c.CoreV1().Pods(ns).GetLogs(podName, &corev1.PodLogOptions{Container: containerName}).DoRaw(ctx)
 		if err == nil {
 			logs = string(rawLogs)
-			if strings.Contains(logs, expectedText) {
+			if logsContainExactLine(logs, expectedText) {
 				pass = true
 				break
 			}
@@ -748,12 +746,30 @@ func verifyHardwareInLogs(ctx context.Context, t *testing.T, c kubernetes.Interf
 	}
 
 	if pass {
-		t.Logf("PASS: %s isolation/access verified.", containerName)
-	} else if expectSuccess {
-		t.Errorf("FAIL: Container %s in Pod %s should see '%s'. Logs: %s", containerName, podName, expectedText, logs)
+		t.Logf("PASS: %s sees exactly %d accelerator device(s).", containerName, expectedCount)
+	} else if expectedCount > 0 {
+		t.Errorf("FAIL: Container %s in Pod %s should see exactly %d accelerator device(s). Logs: %s", containerName, podName, expectedCount, logs)
 	} else {
-		t.Errorf("VIOLATION: Unauthorized Container %s in Pod %s saw '%s'! Logs: %s", containerName, podName, expectedText, logs)
+		t.Errorf("VIOLATION: Unauthorized Container %s in Pod %s should see no accelerator devices. Logs: %s", containerName, podName, logs)
 	}
+}
+
+func logsContainExactLine(logs, expected string) bool {
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.TrimSpace(line) == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func acceleratorProbeCommand(devicePattern string) string {
+	return fmt.Sprintf(`count=0
+for device in %s; do
+  [ -e "$device" ] || continue
+  count=$((count + 1))
+done
+echo "%s$count"`, devicePattern, acceleratorCountResultPrefix)
 }
 
 // Returns a container that probes for accelerator
@@ -763,7 +779,7 @@ func acceleratorProbingContainer(name string, cfg AcceleratorConfig) corev1.Cont
 		Image:   "ubuntu:22.04",
 		Command: []string{"/bin/sh", "-c"},
 		Args: []string{
-			fmt.Sprintf("if ls %s > /dev/null 2>&1; then echo 'RESULT: ACCELERATOR_FOUND'; else echo 'RESULT: ACCELERATOR_MISSING'; fi; sleep 3600", cfg.DevicePath),
+			acceleratorProbeCommand(cfg.DevicePattern) + "\nsleep 3600",
 		},
 	}
 }
@@ -771,4 +787,3 @@ func acceleratorProbingContainer(name string, cfg AcceleratorConfig) corev1.Cont
 func randomNamespaceName(prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, rand.String(5))
 }
-


### PR DESCRIPTION
Fixes #78: https://github.com/kubernetes-sigs/ai-conformance/issues/78

## What this changes

- Replaces the broad `/dev/nvidia*` existence probe with a vendor-configured `DevicePattern`. NVIDIA now counts only `/dev/nvidia[0-9]*` data-device entries, excluding control devices.
- Reports the observed device count and requires it to equal the requested count for authorized containers and zero for unauthorized containers. The shared probe covers both DRA and device-plugin allocation modes.
- Uses one request-count constant for the DRA claim, device-plugin resource limit, and verification assertion.
- Adds hermetic tests for numbered-device counting, no-match behavior, control-device exclusion, and over-allocation detection.

## Verification

- `go test -race ./test -run "Test(DetectAllocationMode|ExtendedResourceGuardFailsClosed|LookupAcceleratorConfig|BuildTestPod|PodGeneratedClaims|DeleteAndAwaitRelease|AcceleratorProbeCommand|LogsContainExactLine)$"`
- `go vet ./test`
- `go mod tidy -diff`
- `gofmt` and `git diff --check`
